### PR TITLE
add workflow for PR

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,19 @@
+name: PR
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go 1.21.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Run tests
+        run: |
+          make build
+          make test

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=pkg/controllers/resources
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/..." output:crd:artifacts:config=pkg/controllers/resources
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.


### PR DESCRIPTION
Added a workflow for PRs. 

Updated the controller gen path to api only otherwise compiler look for [embedded files](https://github.com/cnoe-io/idpbuilder/blob/5e87a01dbebd81028d6f76eaf627b1d82010b3b6/pkg/controllers/crd.go#L19) that's not yet generated and fails.

```
make manifests
mkdir -p /home/ssm-user/t/bin
test -s /home/ssm-user/t/bin/controller-gen && /home/ssm-user/t/bin/controller-gen --version | grep -q v0.12.0 || \
GOBIN=/home/ssm-user/t/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.0
/home/ssm-user/t/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=pkg/controllers/resources
pkg/controllers/crd.go:19:12: pattern resources/*.yaml: no matching files found
Error: not all generators ran successfully
run `controller-gen rbac:roleName=manager-role crd webhook paths=./... output:crd:artifacts:config=pkg/controllers/resources -w` to see all available markers, or `controller-gen rbac:roleName=manager-role crd webhook paths=./... output:crd:artifacts:config=pkg/controllers/resources -h` for usage
make: *** [Makefile:42: manifests] Error 1
```

 As far as I can tell, all controller-gen stuff is under api. 