### PR TITLE
Issue 12

### DIFF
--- a/pkg/apps/srv/backstage/install.yaml
+++ b/pkg/apps/srv/backstage/install.yaml
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
         - name: backstage
-          image: backstage:1.0.0
+          image: public.ecr.aws/cnoe-io/backstage:v0.0.3
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
- See: Issue #12 
- Change the reference of the backstage image to use the one released on public.ecr.aws by cnoe-io instead of backstage 1.0.0 released on docker hub