### PR TITLE
Add service and ingress resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This can be useful in several ways:
 
 Kubernetes: `kubectl get pods`
 
-Argo: Visit https://argocd.idpbuilder.cnoe.io.local:8443/
+Argo: https://argocd.idpbuilder.cnoe.io.localtest.me:8443/
 
-Backstage: http://backstage.idpbuilder.cnoe.io.local/
+Backstage: https://backstage.idpbuilder.cnoe.io.localtest.me:8443/
 
 ## Architecture
 

--- a/pkg/apps/srv/argocd/ingress.yaml
+++ b/pkg/apps/srv/argocd/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   ingressClassName: "nginx"
   rules:
-  - host: argocd.idpbuilder.cnoe.io.local
+  - host: argocd.idpbuilder.cnoe.io.localtest.me
     http:
       paths:
       - path: /

--- a/pkg/apps/srv/backstage/install.yaml
+++ b/pkg/apps/srv/backstage/install.yaml
@@ -130,7 +130,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - host: backstage.idpbuilder.cnoe.io.local
+    - host: backstage.idpbuilder.cnoe.io.localtest.me
       http:
         paths:
           - backend:
@@ -152,17 +152,17 @@ data:
   app-config.yaml: |
     app:
       title: CNOE
-      baseUrl: "https://backstage.idpbuilder.cnoe.io.local:8443"
+      baseUrl: "https://backstage.idpbuilder.cnoe.io.localtest.me:8443"
     organization:
       name: CNOE
     backend:
-      baseUrl: "https://backstage.idpbuilder.cnoe.io.local:8443"
+      baseUrl: "https://backstage.idpbuilder.cnoe.io.localtest.me:8443"
       listen:
         port: 7007
       csp:
         connect-src: ["'self'", 'http:', 'https:']
       cors:
-        origin: "https://backstage.idpbuilder.cnoe.io.local:8443"
+        origin: "https://backstage.idpbuilder.cnoe.io.localtest.me:8443"
         methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
         credentials: true
       database:

--- a/pkg/apps/srv/backstage/install.yaml
+++ b/pkg/apps/srv/backstage/install.yaml
@@ -152,17 +152,17 @@ data:
   app-config.yaml: |
     app:
       title: CNOE
-      baseUrl: http://localhost:3000
+      baseUrl: "https://backstage.idpbuilder.cnoe.io.local:8443"
     organization:
       name: CNOE
     backend:
-      baseUrl: http://localhost:7007
+      baseUrl: "https://backstage.idpbuilder.cnoe.io.local:8443"
       listen:
         port: 7007
       csp:
         connect-src: ["'self'", 'http:', 'https:']
       cors:
-        origin: http://localhost:3000
+        origin: "https://backstage.idpbuilder.cnoe.io.local:8443"
         methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
         credentials: true
       database:

--- a/pkg/apps/srv/backstage/install.yaml
+++ b/pkg/apps/srv/backstage/install.yaml
@@ -98,12 +98,48 @@ spec:
           image: public.ecr.aws/cnoe-io/backstage:v0.0.3
           imagePullPolicy: IfNotPresent
           ports:
-            - name: http
+            - name: backend
               containerPort: 7007
           volumeMounts:
             - mountPath: /app/config
               name: backstage-config
               readOnly: true
+---
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  ports:
+    - name: http-backend
+      port: 7007
+      protocol: TCP
+      targetPort: backend
+  selector:
+    app: backstage
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: backstage.idpbuilder.cnoe.io.local
+      http:
+        paths:
+          - backend:
+              service:
+                name: backstage
+                port:
+                  number: 7007
+            path: /
+            pathType: Prefix
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/controllers/gitserver/controller.go
+++ b/pkg/controllers/gitserver/controller.go
@@ -23,7 +23,7 @@ import (
 const (
 	gitServerResourceName            string = "gitserver"
 	gitServerDeploymentContainerName string = "httpd"
-	gitServerIngressHostnameBase     string = ".idpbuilder.cnoe.io.local"
+	gitServerIngressHostnameBase     string = ".idpbuilder.cnoe.io.localtest.me"
 	repoUrlFmt                       string = "http://%s.%s.svc/idpbuilder-resources.git"
 )
 

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -24,7 +24,7 @@ const (
 	EmbeddedGitServerName            string = "embedded"
 	gitServerResourceName            string = "gitserver"
 	gitServerDeploymentContainerName string = "httpd"
-	gitServerIngressHostnameBase     string = ".idpbuilder.cnoe.io.local"
+	gitServerIngressHostnameBase     string = ".idpbuilder.cnoe.io.localtest.me"
 	repoUrlFmt                       string = "http://%s.%s.svc/idpbuilder-resources.git"
 )
 


### PR DESCRIPTION
- Issue: #22 
- Adding the definition about the Service and Ingress kubernetes resource to expose backstage using the host: `https://backstage.idpbuilder.cnoe.io.local:8443`

Remarks: 
- The UI reports as error `Fail to load entity kinds` when we navigate to `https://backstage.idpbuilder.cnoe.io.local:8443/catalog`. This problem is most probably due to cors badly defined as described here: https://github.com/backstage/backstage/issues/15403 
- If later, we also deploy cert manager, then we could add an annotation to the ingress resource to get the TLS secret populated by the cert manager