### PR TITLE
Fix wrong argocd project name from idpbuilder-embedded-gitserver to idpbuilder-local-gitserver

### DIFF
--- a/pkg/apps/srv/crossplane/crossplane.yaml
+++ b/pkg/apps/srv/crossplane/crossplane.yaml
@@ -13,7 +13,7 @@ spec:
     targetRevision: 1.11.1
     helm:
       releaseName: crossplane
-  project: idpbuilder-embedded-gitserver
+  project: idpbuilder-local-gitserver
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
- Issue: #42 
- Fix wrong argocd project name from idpbuilder-embedded-gitserver to idpbuilder-local-gitserver for Crossplane

```
ARGOCD_SERVER=argocd.idpbuilder.cnoe.io.localtest.me:8443
ARGOCD_USER=admin
ARGOCD_PWD=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)

argocd login --insecure $ARGOCD_SERVER --username $ARGOCD_USER --password $ARGOCD_PWD
'admin:login' logged in successfully
Context 'argocd.idpbuilder.cnoe.io.localtest.me:8443' updated

argocd app list
NAME                                             CLUSTER                         NAMESPACE          PROJECT                     STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO                                                                     PATH           TARGET
argocd/crossplane-helm                           https://kubernetes.default.svc  crossplane-system  idpbuilder-local-gitserver  Synced  Healthy  Auto-Prune  <none>      https://charts.crossplane.io/stable                                                     1.11.1
argocd/idpbuilder-local-gitserver-argocd         https://kubernetes.default.svc  argocd             idpbuilder-local-gitserver  Synced  Healthy  Auto        <none>      http://gitserver-embedded.idpbuilder-local.svc/idpbuilder-resources.git  argocd         HEAD
argocd/idpbuilder-local-gitserver-backstage      https://kubernetes.default.svc  argocd             idpbuilder-local-gitserver  Synced  Healthy  Auto        <none>      http://gitserver-embedded.idpbuilder-local.svc/idpbuilder-resources.git  backstage      HEAD
argocd/idpbuilder-local-gitserver-crossplane     https://kubernetes.default.svc  argocd             idpbuilder-local-gitserver  Synced  Healthy  Auto        <none>      http://gitserver-embedded.idpbuilder-local.svc/idpbuilder-resources.git  crossplane     HEAD
argocd/idpbuilder-local-gitserver-nginx-ingress  https://kubernetes.default.svc  argocd             idpbuilder-local-gitserver  Synced  Healthy  Auto        <none>      http://gitserver-embedded.idpbuilder-local.svc/idpbuilder-resources.git  nginx-ingress  HEAD
```