### PR TITLE
Remove non needed 2nd kubernetes node

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If it is needed to expose some extra Ports between the docker container and the 
 `./idpbuilder create --extraPorts 22:32222`
 
 It is also possible to use your own kind config file
-`./idpbuilder create --buildName local --kindConfig ./my-kind.cfg`
+`./idpbuilder create --buildName local --kindConfig ./my-kind.yaml`
 
 **NOTE**: Be sure to include in your kind config the section `containerdConfigPatches` where the registry hostname includes the name specified with the parameter: `--buildname`
 ```yaml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ You can also define the kubernetes version to image and which corresponds to the
 If it is needed to expose some extra Ports between the docker container and the kubernetes host, they can be declared as such
 `./idpbuilder create --extraPorts 22:32222`
 
+It is also possible to use your own kind config file
+`./idpbuilder create --buildName local --kindConfig ./my-kind.cfg`
+
 ### Use
 
 Kubernetes: `kubectl get pods`

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ This can be useful in several ways:
 
 `./idpbuilder create --buildName localdev`
 
+You can also define the kubernetes version to image and which corresponds to the kind pre-built [image](https://github.com/kubernetes-sigs/kind/releases).
+`./idpbuilder create --kubeVersion v1.27.3`
+
+If it is needed to expose some extra Ports between the docker container and the kubernetes host, they can be declared as such
+`./idpbuilder create --extraPorts 22:32222`
+
 ### Use
 
 Kubernetes: `kubectl get pods`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ If it is needed to expose some extra Ports between the docker container and the 
 It is also possible to use your own kind config file
 `./idpbuilder create --buildName local --kindConfig ./my-kind.cfg`
 
+**NOTE**: Be sure to include in your kind config the section `containerdConfigPatches` where the registry hostname includes the name specified with the parameter: `--buildname`
+```yaml
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://idpbuilder-<localBuildName>-registry:5000"]
+```
+
 ### Use
 
 Kubernetes: `kubectl get pods`

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/google/go-cmp v0.5.9
 	github.com/spf13/cobra v1.7.0
+	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.26.2
 	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.26.2
@@ -103,6 +104,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/pkg/apps/srv/nginx-ingress/ingress-nginx.yaml
+++ b/pkg/apps/srv/nginx-ingress/ingress-nginx.yaml
@@ -501,17 +501,9 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       nodeSelector:
-        ingress-ready: "true"
         kubernetes.io/os: linux
       serviceAccountName: ingress-nginx
       terminationGracePeriodSeconds: 0
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-        operator: Equal
       volumes:
       - name: webhook-cert
         secret:

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -21,24 +21,28 @@ var (
 )
 
 type Build struct {
-	name           string
-	kubeConfigPath string
-	scheme         *runtime.Scheme
-	CancelFunc     context.CancelFunc
+	name              string
+	kubeConfigPath    string
+	kubeVersion       string
+	extraPortsMapping string
+	scheme            *runtime.Scheme
+	CancelFunc        context.CancelFunc
 }
 
-func NewBuild(name, kubeConfigPath string, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
+func NewBuild(name, kubeVersion, kubeConfigPath, extraPortsMapping string, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
 	return &Build{
-		name:           name,
-		kubeConfigPath: kubeConfigPath,
-		scheme:         scheme,
-		CancelFunc:     ctxCancel,
+		name:              name,
+		kubeConfigPath:    kubeConfigPath,
+		kubeVersion:       kubeVersion,
+		extraPortsMapping: extraPortsMapping,
+		scheme:            scheme,
+		CancelFunc:        ctxCancel,
 	}
 }
 
 func (b *Build) ReconcileKindCluster(ctx context.Context, recreateCluster bool) error {
 	// Initialize Kind Cluster
-	cluster, err := kind.NewCluster(b.name, b.kubeConfigPath)
+	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.extraPortsMapping)
 	if err != nil {
 		setupLog.Error(err, "Error Creating kind cluster")
 		return err

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,6 +22,7 @@ var (
 
 type Build struct {
 	name              string
+	kindConfigPath    string
 	kubeConfigPath    string
 	kubeVersion       string
 	extraPortsMapping string
@@ -29,9 +30,10 @@ type Build struct {
 	CancelFunc        context.CancelFunc
 }
 
-func NewBuild(name, kubeVersion, kubeConfigPath, extraPortsMapping string, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
+func NewBuild(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
 	return &Build{
 		name:              name,
+		kindConfigPath:    kindConfigPath,
 		kubeConfigPath:    kubeConfigPath,
 		kubeVersion:       kubeVersion,
 		extraPortsMapping: extraPortsMapping,
@@ -42,7 +44,7 @@ func NewBuild(name, kubeVersion, kubeConfigPath, extraPortsMapping string, schem
 
 func (b *Build) ReconcileKindCluster(ctx context.Context, recreateCluster bool) error {
 	// Initialize Kind Cluster
-	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.extraPortsMapping)
+	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.kindConfigPath, b.extraPortsMapping)
 	if err != nil {
 		setupLog.Error(err, "Error Creating kind cluster")
 		return err

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -22,6 +22,7 @@ var (
 	buildName         string
 	kubeVersion       string
 	extraPortsMapping string
+	kindConfigPath    string
 )
 
 var CreateCmd = &cobra.Command{
@@ -36,6 +37,7 @@ func init() {
 	CreateCmd.PersistentFlags().StringVar(&buildName, "buildName", "localdev", "Name for build (Prefix for kind cluster name, pod names, etc).")
 	CreateCmd.PersistentFlags().StringVar(&kubeVersion, "kubeVersion", "v1.26.333", "Version of the kind kubernetes cluster to create.")
 	CreateCmd.PersistentFlags().StringVar(&extraPortsMapping, "extraPorts", "", "List of extra ports to expose on the docker container and kubernetes cluster as nodePort (e.g. \"22:32222,9090:39090,etc\").")
+	CreateCmd.PersistentFlags().StringVar(&kindConfigPath, "kindConfig", "", "Path of the kind config file to be used instead of the default.")
 
 	zapfs := flag.NewFlagSet("zap", flag.ExitOnError)
 	opts := zap.Options{
@@ -58,7 +60,7 @@ func create(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, extraPortsMapping, k8s.GetScheme(), ctxCancel)
+	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping, k8s.GetScheme(), ctxCancel)
 
 	if err := b.Run(ctx, recreateCluster); err != nil {
 		return err

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -18,20 +18,24 @@ import (
 
 var (
 	// Flags
-	recreateCluster bool
-	buildName       string
+	recreateCluster   bool
+	buildName         string
+	kubeVersion       string
+	extraPortsMapping string
 )
 
 var CreateCmd = &cobra.Command{
 	Use:   "create",
-	Short: "(Re)Create a UCP cluster",
+	Short: "(Re)Create an IDP cluster",
 	Long:  ``,
 	RunE:  create,
 }
 
 func init() {
 	CreateCmd.PersistentFlags().BoolVar(&recreateCluster, "recreate", false, "Delete cluster first if it already exists.")
-	CreateCmd.PersistentFlags().StringVar(&buildName, "buildName", "localdev", "Name for build (Prefix for kind cluster name, pod names, etc)")
+	CreateCmd.PersistentFlags().StringVar(&buildName, "buildName", "localdev", "Name for build (Prefix for kind cluster name, pod names, etc).")
+	CreateCmd.PersistentFlags().StringVar(&kubeVersion, "kubeVersion", "v1.26.333", "Version of the kind kubernetes cluster to create.")
+	CreateCmd.PersistentFlags().StringVar(&extraPortsMapping, "extraPorts", "", "List of extra ports to expose on the docker container and kubernetes cluster as nodePort (e.g. \"22:32222,9090:39090,etc\").")
 
 	zapfs := flag.NewFlagSet("zap", flag.ExitOnError)
 	opts := zap.Options{
@@ -54,7 +58,7 @@ func create(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	b := build.NewBuild(buildName, kubeConfigPath, k8s.GetScheme(), ctxCancel)
+	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, extraPortsMapping, k8s.GetScheme(), ctxCancel)
 
 	if err := b.Run(ctx, recreateCluster); err != nil {
 		return err

--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 	"strings"
 	"text/template"
 
@@ -17,6 +18,7 @@ type Cluster struct {
 	name              string
 	kubeVersion       string
 	kubeConfigPath    string
+	kindConfigPath    string
 	extraPortsMapping string
 }
 
@@ -32,6 +34,16 @@ func SplitFunc(input, sep string) []string {
 	return strings.Split(input, sep)
 }
 func (c *Cluster) getConfig() ([]byte, error) {
+
+	if c.kindConfigPath != "" {
+		f, err := os.ReadFile(c.kindConfigPath)
+		if err != nil {
+			return []byte{}, err
+		} else {
+			return f, nil
+		}
+	}
+
 	rawConfigTempl, err := fs.ReadFile(configFS, "resources/kind.yaml")
 	if err != nil {
 		return []byte{}, err
@@ -78,12 +90,13 @@ func (c *Cluster) getConfig() ([]byte, error) {
 	return retBuff.Bytes(), nil
 }
 
-func NewCluster(name, kubeVersion, kubeConfigPath, extraPortsMapping string) (*Cluster, error) {
+func NewCluster(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string) (*Cluster, error) {
 	provider := cluster.NewProvider(cluster.ProviderWithDocker())
 
 	return &Cluster{
 		provider:          provider,
 		name:              name,
+		kindConfigPath:    kindConfigPath,
 		kubeVersion:       kubeVersion,
 		kubeConfigPath:    kubeConfigPath,
 		extraPortsMapping: extraPortsMapping,

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestGetConfig(t *testing.T) {
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "")
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}
@@ -45,7 +45,7 @@ nodes:
 }
 
 func TestExtraPortMappings(t *testing.T) {
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "22:32222")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222")
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -1,13 +1,12 @@
 package kind
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetConfig(t *testing.T) {
-	cluster, err := NewCluster("testcase", "")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "")
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}
@@ -17,43 +16,72 @@ func TestGetConfig(t *testing.T) {
 		t.Errorf("Error getting kind config: %v", err)
 	}
 
-	expectConfig := `# two node (one workers) cluster config
-	# Kind kubernetes release images https://github.com/kubernetes-sigs/kind/releases
-	kind: Cluster
-	apiVersion: kind.x-k8s.io/v1alpha4
-	containerdConfigPatches:
-	- |-
-	  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
-		endpoint = ["http://idpbuilder-registry:5000"]
-	nodes:
-	- role: control-plane
-	  image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
-	  kubeadmConfigPatches:
-	  - |
-		kind: InitConfiguration
-		nodeRegistration:
-		  kubeletExtraArgs:
-			system-reserved: memory=4Gi
-			node-labels: "ingress-ready=true"
-	  extraPortMappings:
-	  - containerPort: 80
-		hostPort: 8880
-		protocol: TCP
-	  - containerPort: 443
-		hostPort: 8443
-		protocol: TCP
-	  -
-	- role: worker
-	  image: "kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1"
-	  kubeadmConfigPatches:
-	  - |
-		kind: JoinConfiguration
-		nodeRegistration:
-		  kubeletExtraArgs:
-			system-reserved: memory=4Gi`
+	expectConfig := `# Kind kubernetes release images https://github.com/kubernetes-sigs/kind/releases
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://idpbuilder-testcase-registry:5000"]
+nodes:
+- role: control-plane
+  image: "kindest/node:v1.26.3"
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        system-reserved: memory=4Gi
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8880
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 8443
+    protocol: TCP
+  `
+	assert.Equal(t, expectConfig, string(cfg))
+}
 
-	t.Errorf("Got config: %s", string(cfg))
-	if diff := cmp.Diff(expectConfig, string(cfg)); diff != "" {
-		t.Errorf("Expected config mismatch (-want +got):\n%s", diff)
+func TestExtraPortMappings(t *testing.T) {
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "22:32222")
+	if err != nil {
+		t.Fatalf("Initializing cluster resource: %v", err)
 	}
+
+	cfg, err := cluster.getConfig()
+	if err != nil {
+		t.Errorf("Error getting kind config: %v", err)
+	}
+
+	expectConfig := `# Kind kubernetes release images https://github.com/kubernetes-sigs/kind/releases
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://idpbuilder-testcase-registry:5000"]
+nodes:
+- role: control-plane
+  image: "kindest/node:v1.26.3"
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        system-reserved: memory=4Gi
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 8880
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 8443
+    protocol: TCP
+  - containerPort: 32222
+    hostPort: 22
+    protocol: TCP`
+
+	assert.Equal(t, expectConfig, string(cfg))
 }

--- a/pkg/kind/registry_test.go
+++ b/pkg/kind/registry_test.go
@@ -20,7 +20,7 @@ func TestReconcileRegistry(t *testing.T) {
 	defer dockerCli.Close()
 
 	// Create cluster
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "")
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}

--- a/pkg/kind/registry_test.go
+++ b/pkg/kind/registry_test.go
@@ -20,7 +20,7 @@ func TestReconcileRegistry(t *testing.T) {
 	defer dockerCli.Close()
 
 	// Create cluster
-	cluster, err := NewCluster("testcase", "")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "")
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}

--- a/pkg/kind/resources/kind.yaml
+++ b/pkg/kind/resources/kind.yaml
@@ -1,4 +1,3 @@
-# two node (one workers) cluster config
 # Kind kubernetes release images https://github.com/kubernetes-sigs/kind/releases
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -8,7 +7,7 @@ containerdConfigPatches:
     endpoint = ["http://{{ .RegistryHostname }}:{{ .InternalRegistryPort }}"]
 nodes:
 - role: control-plane
-  image: "kindest/node:v1.26.3"
+  image: "kindest/node:{{ .KubernetesVersion }}"
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -23,12 +22,6 @@ nodes:
   - containerPort: 443
     hostPort: 8443
     protocol: TCP
-  -
-- role: worker
-  image: "kindest/node:v1.26.3"
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        system-reserved: memory=4Gi
+  {{ range .ExtraPortsMapping }}- containerPort: {{ .ContainerPort }}
+    hostPort: {{ .HostPort }}
+    protocol: TCP{{ end }}


### PR DESCRIPTION
- Issue #54
- Remove non needed 2nd kubernetes node to deploy only the control plane
- Add 2 new parameters to allow to set the kube version and extraPortMappings