### PR TITLE
use argocd default project

### DIFF
--- a/pkg/apps/srv/crossplane/crossplane.yaml
+++ b/pkg/apps/srv/crossplane/crossplane.yaml
@@ -13,7 +13,7 @@ spec:
     targetRevision: 1.11.1
     helm:
       releaseName: crossplane
-  project: idpbuilder-local-gitserver
+  project: default
   syncPolicy:
     automated:
       prune: true

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -35,7 +35,7 @@ var CreateCmd = &cobra.Command{
 func init() {
 	CreateCmd.PersistentFlags().BoolVar(&recreateCluster, "recreate", false, "Delete cluster first if it already exists.")
 	CreateCmd.PersistentFlags().StringVar(&buildName, "buildName", "localdev", "Name for build (Prefix for kind cluster name, pod names, etc).")
-	CreateCmd.PersistentFlags().StringVar(&kubeVersion, "kubeVersion", "v1.26.333", "Version of the kind kubernetes cluster to create.")
+	CreateCmd.PersistentFlags().StringVar(&kubeVersion, "kubeVersion", "v1.26.3", "Version of the kind kubernetes cluster to create.")
 	CreateCmd.PersistentFlags().StringVar(&extraPortsMapping, "extraPorts", "", "List of extra ports to expose on the docker container and kubernetes cluster as nodePort (e.g. \"22:32222,9090:39090,etc\").")
 	CreateCmd.PersistentFlags().StringVar(&kindConfigPath, "kindConfig", "", "Path of the kind config file to be used instead of the default.")
 

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	defaultArgoCDProjectName         string = "default"
 	EmbeddedGitServerName            string = "embedded"
 	gitServerResourceName            string = "gitserver"
 	gitServerDeploymentContainerName string = "httpd"
@@ -236,7 +237,7 @@ func (r *LocalbuildReconciler) ReconcileArgoApps(ctx context.Context, req ctrl.R
 				app,
 				repoUrl,
 				embedApp.Path,
-				resource.GetArgoProjectName(),
+				defaultArgoCDProjectName,
 				nil,
 			)
 


### PR DESCRIPTION
fixes: #42 

As discussed in the issue above, we will use the default project for this release to ensure all embedded apps deploy.  I also fixed the default kind image tag.

```bash
kubectl get applications -n argocd -o custom-columns="NAME":.metadata.name,"PROJECT":.spec.project
NAME                                       PROJECT
crossplane-helm                            default
idpbuilder-local-gitserver-argocd          default
idpbuilder-local-gitserver-backstage       default
idpbuilder-local-gitserver-crossplane      default
idpbuilder-local-gitserver-nginx-ingress   default
```