### PR TITLE
fix argocd controller tests

### DIFF
--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -11,12 +11,12 @@ func TestGetRawInstallResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetRawInstallResources() error: %v", err)
 	}
-	if len(resources) != 2 {
+	if len(resources) != 1 {
 		t.Fatalf("GetRawInstallResources() resources len != 1, got %d", len(resources))
 	}
 
 	resourcePrefix := "# UCP ARGO INSTALL RESOURCES\n"
-	checkPrefix := resources[1][0:len(resourcePrefix)]
+	checkPrefix := resources[0][0:len(resourcePrefix)]
 	if resourcePrefix != string(checkPrefix) {
 		t.Fatalf("GetRawInstallResources() exptected 1 resource with prefix %q, got %q", resourcePrefix, checkPrefix)
 	}
@@ -28,7 +28,7 @@ func TestGetK8sInstallResources(t *testing.T) {
 		t.Fatalf("GetK8sInstallResources() error: %v", err)
 	}
 
-	if len(objs) != 57 {
+	if len(objs) != 55 {
 		t.Fatalf("Expected 57 Argo Install Resources, got: %d", len(objs))
 	}
 }


### PR DESCRIPTION
```bash
➜  cnoe/idpbuilder git:(fix/tests) ✗ yq ea '[.] | length' pkg/controllers/localbuild/resources/argo/install.yaml
55
➜  cnoe/idpbuilder git:(fix/tests) ✗ ls -lh pkg/controllers/localbuild/resources/argo/
total 2152
-rw-r--r--  1 mccloman  staff   1.0M Sep 29 10:06 install.yaml
```

So the number of resources should be 1 and the number of objects in the argocd resource file should be 55. 

We will need to make a bit more robust tests in the future but I want to fix these tests so that they don't show up as failures every PR.