### PR TITLE
create kind network

### DIFF
--- a/pkg/kind/registry_test.go
+++ b/pkg/kind/registry_test.go
@@ -47,6 +47,7 @@ func TestReconcileRegistry(t *testing.T) {
 			break
 		}
 		t.Logf("Failed to reconcile: %v", err)
+		dockerCli.ContainerRemove(ctx, cluster.getRegistryContainerName(), types.ContainerRemoveOptions{Force: true})
 		time.Sleep(waitInterval)
 	}
 

--- a/pkg/kind/registry_test.go
+++ b/pkg/kind/registry_test.go
@@ -19,6 +19,12 @@ func TestReconcileRegistry(t *testing.T) {
 	}
 	defer dockerCli.Close()
 
+	kindNetwork, err := dockerCli.NetworkCreate(ctx, "kind", types.NetworkCreate{})
+	if err != nil {
+		t.Fatalf("Failed creaking kind network: %v", err)
+	}
+	defer dockerCli.NetworkRemove(ctx, kindNetwork.ID)
+
 	// Create cluster
 	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "")
 	if err != nil {
@@ -36,6 +42,8 @@ func TestReconcileRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting registry container after reconcile: %v", err)
 	}
+	defer dockerCli.ImageRemove(ctx, container.ImageID, types.ImageRemoveOptions{})
+
 	if container == nil {
 		t.Fatal("Expected registry container after reconcile but got nil")
 	}

--- a/pkg/kind/registry_test.go
+++ b/pkg/kind/registry_test.go
@@ -33,6 +33,7 @@ func TestReconcileRegistry(t *testing.T) {
 
 	// Create registry
 	err = cluster.ReconcileRegistry(ctx)
+	defer dockerCli.ContainerRemove(ctx, cluster.getRegistryContainerName(), types.ContainerRemoveOptions{Force: true})
 	if err != nil {
 		t.Fatalf("Error reconciling registry: %v", err)
 	}
@@ -52,10 +53,5 @@ func TestReconcileRegistry(t *testing.T) {
 	err = cluster.ReconcileRegistry(ctx)
 	if err != nil {
 		t.Fatalf("Error reconciling registry: %v", err)
-	}
-
-	// Cleanup
-	if err = dockerCli.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
-		t.Fatalf("Error removing registry docker container after reconcile: %v", err)
 	}
 }


### PR DESCRIPTION
The test assume we have a docker network named "kind". Since the test only cares about registry image, we'll just create the network prior to reconciling. 

Note that we will not need this functionality going forward. If we did, I think the way @cmoulliard did with test containers is the way to go. I want to fix tests so we don't run into test failures for unrelated PRs. 

```bash
ubuntu@ip-10-192-11-119:~/idpbuilder$ go test github.com/cnoe-io/idpbuilder/pkg/kind -run '^\QTestReconcileRegistry\E$'
ok  	github.com/cnoe-io/idpbuilder/pkg/kind	4.495s
ubuntu@ip-10-192-11-119:~/idpbuilder$ docker images
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
ubuntu@ip-10-192-11-119:~/idpbuilder$ docker network ls
NETWORK ID     NAME      DRIVER    SCOPE
906d8469762b   bridge    bridge    local
90ea394ecb86   host      host      local
44350ca9e837   none      null      local
```

fixes: #28 