### PR TITLE
start registry container

### DIFF
--- a/pkg/controllers/gitserver/image_test.go
+++ b/pkg/controllers/gitserver/image_test.go
@@ -3,6 +3,11 @@ package gitserver
 import (
 	"context"
 	"fmt"
+	"github.com/cnoe-io/idpbuilder/pkg/kind"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -39,23 +44,58 @@ func TestReconcileGitServerImage(t *testing.T) {
 		},
 	}
 
-	_, err = r.reconcileGitServerImage(ctx, controllerruntime.Request{}, &resource)
-	if err != nil {
-		t.Errorf("reconcile error: %v", err)
-	}
-
-	if !strings.HasPrefix(resource.Status.ImageID, "sha256") {
-		t.Errorf("Invalid or no Image ID in status: %q", resource.Status.ImageID)
-	}
-
 	dockerClient, err := docker.GetDockerClient()
 	if err != nil {
 		t.Errorf("Getting docker client: %v", err)
 	}
+	defer dockerClient.Close()
+	reader, err := dockerClient.ImagePull(ctx, "docker.io/library/registry:2", types.ImagePullOptions{})
+	defer reader.Close()
+	// blocks until pull is completed
+	io.Copy(os.Stdout, reader)
+	if err != nil {
+		t.Fatalf("failed pulilng registry image: %v", err)
+	}
 
+	resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
+		Image: "docker.io/library/registry:2",
+		Tty:   false,
+		ExposedPorts: nat.PortSet{
+			nat.Port(fmt.Sprintf("%d/tcp", kind.InternalRegistryPort)): struct{}{},
+		},
+	}, &container.HostConfig{
+		PortBindings: nat.PortMap{
+			nat.Port(fmt.Sprintf("%d/tcp", kind.InternalRegistryPort)): []nat.PortBinding{
+				{
+					HostIP:   "0.0.0.0",
+					HostPort: fmt.Sprintf("%d", kind.ExposedRegistryPort),
+				},
+			},
+		},
+	}, nil, nil, "testcase-registry")
+	if err != nil {
+		t.Fatalf("failed creating registry container %v", err)
+	}
+
+	defer dockerClient.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{Force: true})
+
+	err = dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{})
+	if err != nil {
+		t.Fatalf("failed starting container %v", err)
+	}
+
+	_, err = r.reconcileGitServerImage(ctx, controllerruntime.Request{}, &resource)
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if !strings.HasPrefix(resource.Status.ImageID, "sha256") {
+		t.Fatalf("Invalid or no Image ID in status: %q", resource.Status.ImageID)
+	}
 	imageNameID := fmt.Sprintf("%s@%s", GetImageTag(&resource), resource.Status.ImageID)
 	_, err = dockerClient.ImageRemove(ctx, imageNameID, types.ImageRemoveOptions{})
 	if err != nil {
 		t.Errorf("Removing docker image: %v", err)
 	}
 }
+


### PR DESCRIPTION
Fixes the issue with the test on git image where you get a error message like [this](https://github.com/cnoe-io/idpbuilder/actions/runs/6647695202/job/18063537873#step:4:73)


```
--- FAIL: TestReconcileGitServerImage (19.02s)
    image_test.go:44: reconcile error: Error response from daemon: Get "http://localhost:5001/v2/": dial tcp [::1]:5001: connect: connection refused
    image_test.go:48: Invalid or no Image ID in status: ""
    image_test.go:59: Removing docker image: Error response from daemon: invalid reference format
FAIL
```

It starts a registry container so it can get the digest. Definitely not the best way to go about testing these but we shouldn't need the code tested going forward. 