### PR TITLE
use known namespace

### DIFF
--- a/pkg/controllers/localbuild/installer.go
+++ b/pkg/controllers/localbuild/installer.go
@@ -86,7 +86,7 @@ func (e *EmbeddedInstallation) Install(ctx context.Context, req ctrl.Request, re
 				_ = appsv1.AddToScheme(sch)
 				if gvkObj, err := sch.New(gvk); err == nil {
 					if gotObj, ok := gvkObj.(client.Object); ok {
-						if err := cli.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, gotObj); err != nil {
+						if err := cli.Get(ctx, types.NamespacedName{Namespace: e.namespace, Name: obj.GetName()}, gotObj); err != nil {
 							if err = controllerutil.SetControllerReference(resource, obj, sc); err != nil {
 								log.Error(err, "Setting controller reference for deployment", obj.GetName(), obj)
 								return ctrl.Result{}, err
@@ -132,7 +132,7 @@ func (e *EmbeddedInstallation) Install(ctx context.Context, req ctrl.Request, re
 
 				for {
 					if gotObj, ok := gvkObj.(client.Object); ok {
-						if err := cli.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, gotObj); err != nil {
+						if err := cli.Get(ctx, types.NamespacedName{Namespace: e.namespace, Name: obj.GetName()}, gotObj); err != nil {
 							errCh <- err
 							return
 						}


### PR DESCRIPTION
Instead of relying on install object's namespace, use the known namespace. 

Ran into an issue where the gitea deployment object was not found because the install manifest does not define a namespace. We know where deployment should go, so let's look in that namespace. 