### PR TITLE
prevent git server from running

### DIFF
--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -3,9 +3,7 @@ package controllers
 import (
 	"context"
 
-	"github.com/cnoe-io/idpbuilder/pkg/apps"
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/gitrepository"
-	"github.com/cnoe-io/idpbuilder/pkg/controllers/gitserver"
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/localbuild"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -24,22 +22,7 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		return err
 	}
 
-	// Run GitServer controller
-	appsFS, err := apps.GetAppsFS()
-	if err != nil {
-		log.Error(err, "unable to find srv dir in apps fs")
-		return err
-	}
-	if err := (&gitserver.GitServerReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Content: appsFS,
-	}).SetupWithManager(mgr); err != nil {
-		log.Error(err, "unable to create gitserver controller")
-		return err
-	}
-
-	err = (&gitrepository.RepositoryReconciler{
+	err := (&gitrepository.RepositoryReconciler{
 		Client:          mgr.GetClient(),
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("gitrepository-controller"),

--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -128,7 +128,7 @@ func (c *Cluster) Reconcile(ctx context.Context, recreate bool) error {
 			c.provider.Delete(c.name, "")
 		} else {
 			fmt.Printf("Cluster %s already exists\n", c.name)
-			return c.ReconcileRegistry(ctx)
+			return nil
 		}
 	}
 
@@ -151,7 +151,7 @@ func (c *Cluster) Reconcile(ctx context.Context, recreate bool) error {
 
 	fmt.Printf("Done creating cluster %s\n", c.name)
 
-	return c.ReconcileRegistry(ctx)
+	return nil
 }
 
 func (c *Cluster) ExportKubeConfig(name string, internal bool) error {


### PR DESCRIPTION
Currently the registry container is created and runs even though it is not used by anything. This PR prevents the git server controller from running and creating the registry container.

Part of: https://github.com/cnoe-io/idpbuilder/issues/80