### PR TITLE
enable docker client API version negotiation

### DIFF
--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -14,7 +14,9 @@ import (
 )
 
 func GetDockerClient() (*dockerClient.Client, error) {
-	return dockerClient.NewClientWithOpts()
+	return dockerClient.NewClientWithOpts(
+		dockerClient.WithAPIVersionNegotiation(),
+	)
 }
 
 type AuxBody struct {


### PR DESCRIPTION
Without this, kind fails if the docker server version doesnt specifically match the one we link against. e.g. if running a slightly old docker server this fails.