### PR TITLE
Remove enum validation for embedded app name

### DIFF
--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -16,8 +16,6 @@ type GitRepositorySpec struct {
 }
 
 type GitRepositorySource struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum:=argocd;backstage;crossplane;gitea;nginx
 	EmbeddedAppName string `json:"embeddedAppName"`
 	// Path is the absolute path to directory that contains Kustomize structure or raw manifests.
 	// This is required when Type is set to local.

--- a/api/v1alpha1/gitrepository_types.go
+++ b/api/v1alpha1/gitrepository_types.go
@@ -16,8 +16,8 @@ type GitRepositorySpec struct {
 }
 
 type GitRepositorySource struct {
-	// +kubebuilder:validation:Enum:=argocd;backstage;crossplane;gitea;nginx
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=argocd;backstage;crossplane;gitea;nginx
 	EmbeddedAppName string `json:"embeddedAppName"`
 	// Path is the absolute path to directory that contains Kustomize structure or raw manifests.
 	// This is required when Type is set to local.

--- a/pkg/controllers/resources/idpbuilder.cnoe.io_gitrepositories.yaml
+++ b/pkg/controllers/resources/idpbuilder.cnoe.io_gitrepositories.yaml
@@ -51,12 +51,6 @@ spec:
               source:
                 properties:
                   embeddedAppName:
-                    enum:
-                    - argocd
-                    - backstage
-                    - crossplane
-                    - gitea
-                    - nginx
                     type: string
                   path:
                     description: Path is the absolute path to directory that contains
@@ -71,6 +65,7 @@ spec:
                     - embedded
                     type: string
                 required:
+                - embeddedAppName
                 - type
                 type: object
             required:


### PR DESCRIPTION
Without this, not specifying embeeded app name errors because it does not adhere to the enum validation. I validated that changing the order does not work as well.