### PR TITLE
Print Argo Information After Creation

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -8,10 +8,8 @@ import (
 	"github.com/cnoe-io/idpbuilder/globals"
 	"github.com/cnoe-io/idpbuilder/pkg/controllers"
 	"github.com/cnoe-io/idpbuilder/pkg/kind"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -180,40 +178,4 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 	err = <-managerExit
 	close(managerExit)
 	return err
-}
-
-type ArgoConfig struct {
-	Username string
-	Password string
-	Url      string
-
-}
-
-func (b *Build) GetArgoConfig() (*ArgoConfig, error) {
-	kubeConfig, err := b.GetKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	kubeClient, err := b.GetKubeClient(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	secret := &corev1.Secret{}
-
-	err = kubeClient.Get(context.Background(), types.NamespacedName{
-		Namespace: "argocd",
-		Name: "argocd-initial-admin-secret",
-	}, secret)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ArgoConfig{
-		Username: "admin",
-		Password: string(secret.Data["password"]),
-		Url: "https://argocd.cnoe.localtest.me:8443/",
-	}, nil
-
 }

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -72,10 +72,20 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping, absDirPaths, k8s.GetScheme(), ctxCancel)
-
+	
 	if err := b.Run(ctx, recreateCluster); err != nil {
 		return err
 	}
+
+	argoConfig, err := b.GetArgoConfig()
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("\n\n########################### Finished Creating IDP Successfully! ############################\n\n\n")
+	fmt.Printf("Can Access ArgoCD at %s\nUsername: %s\nPassword: %s\n", argoConfig.Url, argoConfig.Username, argoConfig.Password)
+
+
 	return nil
 }
 

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -72,18 +72,14 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping, absDirPaths, k8s.GetScheme(), ctxCancel)
-	
+
 	if err := b.Run(ctx, recreateCluster); err != nil {
 		return err
 	}
 
-	argoConfig, err := b.GetArgoConfig()
-	if err != nil {
-		return err
-	}
-
 	fmt.Print("\n\n########################### Finished Creating IDP Successfully! ############################\n\n\n")
-	fmt.Printf("Can Access ArgoCD at %s\nUsername: %s\nPassword: %s\n", argoConfig.Url, argoConfig.Username, argoConfig.Password)
+	fmt.Print("Can Access ArgoCD at https://argocd.cnoe.localtest.me:8443/\nUsername: admin\n")
+	fmt.Print(`Password can be retrieved by running: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`, "\n")
 
 
 	return nil


### PR DESCRIPTION
Relates to https://github.com/cnoe-io/idpbuilder/issues/92

Makes it emit a series of log messages after the `idpbuilder create` command completes successfully. Gets the ArgoCD Password from K8s and logs the username/password and URL for ArgoCD.

Emits something like 

```
1.7024070614792352e+09  INFO    controller.custompackage        All workers finished    {"reconciler group": "idpbuilder.cnoe.io", "reconciler kind": "CustomPackage"}
1.702407061479521e+09   INFO    Stopping and waiting for caches
1.702407061479584e+09   INFO    Stopping and waiting for webhooks
1.7024070614795892e+09  INFO    Wait completed, proceeding to shutdown the manager


########################### Finished Creating IDP Successfully! ############################


Can Access ArgoCD at https://argocd.cnoe.localtest.me:8443/
Username: admin
Password can be retrieved by running: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
```