### PR TITLE
add a flag to specify if the cli should exit once packages are synced

### DIFF
--- a/api/v1alpha1/custom_package_types.go
+++ b/api/v1alpha1/custom_package_types.go
@@ -45,6 +45,8 @@ type ArgoCDPackageSpec struct {
 }
 
 type CustomPackageStatus struct {
+	// A Custom package is considered synced when the in-cluster repository url is set as the repository URL
+	// This only applies for a package that references local directories
 	Synced            bool        `json:"synced,omitempty"`
 	GitRepositoryRefs []ObjectRef `json:"gitRepositoryRefs,omitempty"`
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"fmt"
+
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
 	"github.com/cnoe-io/idpbuilder/globals"
 	"github.com/cnoe-io/idpbuilder/pkg/controllers"
@@ -28,11 +29,12 @@ type Build struct {
 	kubeVersion       string
 	extraPortsMapping string
 	customPackageDirs []string
+	exitOnSync        bool
 	scheme            *runtime.Scheme
 	CancelFunc        context.CancelFunc
 }
 
-func NewBuild(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, customPackageDirs []string, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
+func NewBuild(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, customPackageDirs []string, exitOnSync bool, scheme *runtime.Scheme, ctxCancel context.CancelFunc) *Build {
 	return &Build{
 		name:              name,
 		kindConfigPath:    kindConfigPath,
@@ -40,6 +42,7 @@ func NewBuild(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMappi
 		kubeVersion:       kubeVersion,
 		extraPortsMapping: extraPortsMapping,
 		customPackageDirs: customPackageDirs,
+		exitOnSync:        exitOnSync,
 		scheme:            scheme,
 		CancelFunc:        ctxCancel,
 	}
@@ -95,7 +98,7 @@ func (b *Build) ReconcileCRDs(ctx context.Context, kubeClient client.Client) err
 }
 
 func (b *Build) RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error) error {
-	return controllers.RunControllers(ctx, mgr, exitCh, b.CancelFunc)
+	return controllers.RunControllers(ctx, mgr, exitCh, b.CancelFunc, b.exitOnSync)
 }
 
 func (b *Build) Run(ctx context.Context, recreateCluster bool) error {

--- a/pkg/cmd/gitserver/create/root.go
+++ b/pkg/cmd/gitserver/create/root.go
@@ -102,7 +102,7 @@ func create(cmd *cobra.Command, args []string) error {
 
 	// Run controllers
 	managerExit := make(chan error)
-	if err := controllers.RunControllers(ctx, mgr, managerExit, ctxCancel); err != nil {
+	if err := controllers.RunControllers(ctx, mgr, managerExit, ctxCancel, true); err != nil {
 		setupLog.Error(err, "Running controllers")
 		return err
 	}

--- a/pkg/controllers/resources/idpbuilder.cnoe.io_custompackages.yaml
+++ b/pkg/controllers/resources/idpbuilder.cnoe.io_custompackages.yaml
@@ -96,6 +96,9 @@ spec:
                   type: object
                 type: array
               synced:
+                description: A Custom package is considered synced when the in-cluster
+                  repository url is set as the repository URL This only applies for
+                  a package that references local directories
                 type: boolean
             type: object
         type: object

--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/custompackage"
 
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/gitrepository"
@@ -10,13 +11,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error, ctxCancel context.CancelFunc) error {
+func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error, ctxCancel context.CancelFunc, exitOnSync bool) error {
 	log := log.FromContext(ctx)
 
 	// Run Localbuild controller
 	if err := (&localbuild.LocalbuildReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),
+		ExitOnSync: exitOnSync,
 		CancelFunc: ctxCancel,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create localbuild controller")


### PR DESCRIPTION
With this change, cli exits by default. To have it continuously sync, you must provide the new flag `--no-exit`. 

fixes: #107 