### PR TITLE
ensure multi source spec is handled

### DIFF
--- a/pkg/controllers/custompackage/controller.go
+++ b/pkg/controllers/custompackage/controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) reconcileCustomPackage(ctx context.Context, resource *v1alp
 		synced := true
 		if app.Spec.HasMultipleSources() {
 			for j := range app.Spec.Sources {
-				s := app.Spec.Sources[j]
+				s := &app.Spec.Sources[j]
 				res, repo, sErr := r.reconcileArgocdSource(ctx, resource, appName, resource.Spec.ArgoCD.ApplicationFile, s.RepoURL)
 				if sErr != nil {
 					return res, sErr

--- a/pkg/controllers/custompackage/controller.go
+++ b/pkg/controllers/custompackage/controller.go
@@ -190,8 +190,13 @@ func (r *Reconciler) reconcileGitRepo(ctx context.Context, resource *v1alpha1.Cu
 		}
 		return nil
 	})
+	// it's possible for an application to specify the same directory multiple times in the spec.
+	// if there is a repository already created for this package, no further action is necessary.
+	if !errors.IsAlreadyExists(err) {
+		return repo, err
+	}
 
-	return repo, err
+	return repo, nil
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app2
+  namespace: argocd
+spec:
+  destination:
+    namespace: my-app2
+    server: "https://kubernetes.default.svc"
+  sources:
+    - repoURL: cnoe://busybox
+      targetRevision: HEAD
+      path: "."
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2.yaml
@@ -8,9 +8,12 @@ spec:
     namespace: my-app2
     server: "https://kubernetes.default.svc"
   sources:
-    - repoURL: cnoe://busybox
+    - repoURL: cnoe://app2
       targetRevision: HEAD
-      path: "."
+      path: "one"
+    - repoURL: cnoe://app2
+      targetRevision: HEAD
+      path: "two"
   project: default
   syncPolicy:
     automated:

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2/one/busybox.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2/one/busybox.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: argocd
+  labels:
+    abc: ded
+    notused: remove-me
+spec:
+  containers:
+    - image: alpine:3.18
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2/two/busybox.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/app2/two/busybox.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: argocd
+  labels:
+    abc: ded
+    notused: remove-me
+spec:
+  containers:
+    - image: alpine:3.18
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always


### PR DESCRIPTION
Fixes an issue when you are using multi sources in ArgoCD, the repo url was not updated correctly. It was because we were not updating the correct object.