### PR TITLE
allow for logging customization

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var (
@@ -133,6 +134,9 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 	// Create controller manager
 	mgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme: b.scheme,
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "Error creating controller manager")

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -2,19 +2,17 @@ package create
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/cnoe-io/idpbuilder/pkg/build"
+	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	"k8s.io/client-go/util/homedir"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (
@@ -30,10 +28,11 @@ var (
 )
 
 var CreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "(Re)Create an IDP cluster",
-	Long:  ``,
-	RunE:  create,
+	Use:     "create",
+	Short:   "(Re)Create an IDP cluster",
+	Long:    ``,
+	RunE:    create,
+	PreRunE: preCreateE,
 }
 
 func init() {
@@ -45,15 +44,10 @@ func init() {
 	CreateCmd.PersistentFlags().StringVar(&kindConfigPath, "kind-config", "", "Path of the kind config file to be used instead of the default.")
 	CreateCmd.Flags().StringSliceVarP(&extraPackagesDirs, "package-dir", "p", []string{}, "Paths to custom packages")
 	CreateCmd.Flags().BoolVarP(&noExit, "no-exit", "n", true, "When set, idpbuilder will not exit after all packages are synced. Useful for continuously syncing local directories.")
+}
 
-	zapfs := flag.NewFlagSet("zap", flag.ExitOnError)
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(zapfs)
-	CreateCmd.Flags().AddGoFlagSet(zapfs)
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+func preCreateE(cmd *cobra.Command, args []string) error {
+	return helpers.SetLogger()
 }
 
 func create(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/helpers/logger.go
+++ b/pkg/cmd/helpers/logger.go
@@ -1,0 +1,44 @@
+package helpers
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	LogLevel    string
+	LogLevelMsg = "Set the log verbosity. Supported values are: debug, info, warn, and error."
+)
+
+func SetLogger() error {
+	l, err := getSlogLevel(LogLevel)
+	if err != nil {
+		return err
+	}
+	slogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
+	logger := logr.FromSlogHandler(slogger.Handler())
+	klog.SetLogger(logger)
+	ctrl.SetLogger(logger)
+	return nil
+}
+
+func getSlogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelDebug, fmt.Errorf("%s is not a valid log level", s)
+	}
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cnoe-io/idpbuilder/pkg/cmd/create"
+	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
 	"github.com/cnoe-io/idpbuilder/pkg/cmd/version"
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.PersistentFlags().StringVarP(&helpers.LogLevel, "log-level", "l", "info", helpers.LogLevelMsg)
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 }


### PR DESCRIPTION
As mentioned in #15, currently it's not possible to configure logging format or level.

This PR ensures logging customization work and implements our own defaults: RFC3339 timestamps and console logs.
Uses slog as the underlying implementation.