### PR TITLE
generate ingress-nginx manifests

### DIFF
--- a/hack/ingress-nginx/deployment-ingress-nginx.yaml
+++ b/hack/ingress-nginx/deployment-ingress-nginx.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.8.1
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: controller
+          args:
+            - /nginx-ingress-controller
+            - --election-id=ingress-nginx-leader
+            - --controller-class=k8s.io/ingress-nginx
+            - --ingress-class=nginx
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
+            - --watch-ingress-without-class=true
+            - --publish-status-address=localhost
+            - --enable-ssl-passthrough
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              name: http
+              protocol: TCP
+            - containerPort: 443
+              hostPort: 443
+              name: https
+              protocol: TCP

--- a/hack/ingress-nginx/generate-manifests.sh
+++ b/hack/ingress-nginx/generate-manifests.sh
@@ -1,0 +1,5 @@
+INSTALL_YAML="pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml"
+
+echo "# INGRESS-NGINX INSTALL RESOURCES" > ${INSTALL_YAML}
+echo "# This file is auto-generated with 'hack/ingress-nginx/generate-manifests.sh'" >> ${INSTALL_YAML}
+kustomize build ./hack/ingress-nginx/ >> ${INSTALL_YAML}

--- a/hack/ingress-nginx/kustomization.yaml
+++ b/hack/ingress-nginx/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.1/deploy/static/provider/cloud/deploy.yaml
+
+patches:
+  - path: deployment-ingress-nginx.yaml
+  - path: service-ingress-nginx.yaml
+  - target:
+      group: ""
+      version: v1
+      kind: Service
+      name: ingress-nginx-controller
+      namespace: ingress-nginx
+    patch: |-
+      - op: remove
+        path: /spec/externalTrafficPolicy
+      - op: replace
+        path: /spec/type
+        value: NodePort
+

--- a/hack/ingress-nginx/service-ingress-nginx.yaml
+++ b/hack/ingress-nginx/service-ingress-nginx.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - appProtocol: https
+      name: https-8443
+      port: 8443
+      protocol: TCP
+      targetPort: https

--- a/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
+++ b/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
@@ -1,3 +1,5 @@
+# INGRESS-NGINX INSTALL RESOURCES
+# This file is auto-generated with 'hack/ingress-nginx/generate-manifests.sh'
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -348,6 +350,11 @@ spec:
   - IPv4
   ipFamilyPolicy: SingleStack
   ports:
+  - appProtocol: https
+    name: https-8443
+    port: 8443
+    protocol: TCP
+    targetPort: https
   - appProtocol: http
     name: http
     port: 80


### PR DESCRIPTION
This PR adds a script to generate ingress-nginx manifests.

It also adds an alternative internal https port (8443) for ingress-nginx. 

Reason for adding 8443 is that it allows us to support a bit more complex set up where in-cluster URI must match external URI exactly. 

For example, for OIDC endpoint discovery to work, the issuer URL given to clients must match what is returned by the OIDC broker. See below: 

1. Keycloak is installed and configured. Ingress is created, and the endpoint is available at `https://kyecloak.cnoe.localtest.me:8443` on my local machine. 
2. Now, I want to configure Argo Workflows to use the Keycloak instance as IdP. Normally, I specify the externally available keycloak issuer url such as `https://keycloak.cnoe.localtest.me:8443/realms/cnoe`.
3. Unfortunately, I cannot specify `https://kyecloak.cnoe.localtest.me:8443` as the issuer URL because the Argo Workflows API server must first contact OIDC's well-known endpoint, and the name will resolve to `127.0.0.1` in the pod.  
4. I can get it to resolve by creating a rewrite rule in coredns so that `kyecloak.cnoe.localtest.me` becomes `ingress-nginx-controller.ingress-nginx.svc.cluster.local`.
5. Now, the Argo Workflows API server will send requests to `https://ingress-nginx-controller.ingress-nginx.svc.cluster.local:8443/realms/cnoe`. 
6. This doesn't work because ingress-nginx doesn't listen on port 8443.


 