### PR TITLE
dont update localbuild resource status when shutting down

### DIFF
--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -78,15 +78,16 @@ func (r *LocalbuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *LocalbuildReconciler) postProcessReconcile(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) {
 	log := log.FromContext(ctx)
 
-	resource.Status.ObservedGeneration = resource.GetGeneration()
-	if err := r.Status().Update(ctx, resource); err != nil {
-		log.Error(err, "Failed to update resource status after reconcile")
-	}
-
 	log.Info("Checking if we should shutdown")
 	if r.shouldShutdown {
 		log.Info("Shutting Down")
 		r.CancelFunc()
+		return
+	}
+
+	resource.Status.ObservedGeneration = resource.GetGeneration()
+	if err := r.Status().Update(ctx, resource); err != nil {
+		log.Error(err, "Failed to update resource status after reconcile")
 	}
 }
 


### PR DESCRIPTION
updating the resource when shutting down can create a race against a closed context which would throw the following undesirable error.

The PR checks whether we are shutting down before trying to update the localbuild resource. The assumption is that the necessary update to the status should have already happened.


```
1.706661106363861e+09   ERROR   controller.localbuild   Failed to update resource status after reconcile {"reconciler group": "idpbuilder.cnoe.io", "reconciler kind": "Localbuild", "name": "localdev", "namespace":
 "", "error": "client rate limiter Wait returned an error: context canceled"}
github.com/cnoe-io/idpbuilder/pkg/controllers/localbuild.(*LocalbuildReconciler).Reconcile
        /Users/nkaviani/workspaces/git/cnoe/idpbuilder/pkg/controllers/localbuild/controller.go:76
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /Users/nkaviani/.gvm/pkgsets/go1.20/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /Users/nkaviani/.gvm/pkgsets/go1.20/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /Users/nkaviani/.gvm/pkgsets/go1.20/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /Users/nkaviani/.gvm/pkgsets/go1.20/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
```