### PR TITLE
set ingress-nginx buffer size to 32k

### DIFF
--- a/hack/ingress-nginx/cm-ingress-nginx-controller.yaml
+++ b/hack/ingress-nginx/cm-ingress-nginx-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  allow-snippet-annotations: "true"
+  proxy-buffer-size: "32k"

--- a/hack/ingress-nginx/kustomization.yaml
+++ b/hack/ingress-nginx/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 patches:
   - path: deployment-ingress-nginx.yaml
   - path: service-ingress-nginx.yaml
+  - path: cm-ingress-nginx-controller.yaml
   - target:
       group: ""
       version: v1

--- a/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
+++ b/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
@@ -323,6 +323,7 @@ subjects:
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  proxy-buffer-size: 32k
 kind: ConfigMap
 metadata:
   labels:


### PR DESCRIPTION
I was helping @csantanapr with running idpbuilder. Apparently on some systems, it is possible for ingress-nginx's default buffer size to be too small (4k) for header values. 

Error message looks something like: 

```
upstream sent too big header while reading response header from upstream, client
```

Setting the value to 32k resolved the issue. I think we should just set the value to 32k so this doesn't happen.