### PR TITLE
ignore unspecified packaegs when shutting down

### DIFF
--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -226,9 +226,14 @@ func (r *LocalbuildReconciler) shouldShutDown(ctx context.Context, resource *v1a
 	for i := range repos.Items {
 		repo := repos.Items[i]
 
-		_, gErr := util.GetCLIStartTimeAnnotationValue(repo.ObjectMeta.Annotations)
+		startTimeAnnotation, gErr := util.GetCLIStartTimeAnnotationValue(repo.ObjectMeta.Annotations)
 		if gErr != nil {
 			// this means this repository resource is not managed by localbuild
+			continue
+		}
+
+		// this object is not part of this CLI invocation
+		if startTimeAnnotation != cliStartTime {
 			continue
 		}
 
@@ -251,8 +256,12 @@ func (r *LocalbuildReconciler) shouldShutDown(ctx context.Context, resource *v1a
 
 	for i := range pkgs.Items {
 		pkg := pkgs.Items[i]
-		_, gErr := util.GetCLIStartTimeAnnotationValue(pkg.ObjectMeta.Annotations)
+		startTimeAnnotation, gErr := util.GetCLIStartTimeAnnotationValue(pkg.ObjectMeta.Annotations)
 		if gErr != nil {
+			continue
+		}
+
+		if startTimeAnnotation != cliStartTime {
 			continue
 		}
 


### PR DESCRIPTION
There is a situation where the CLI never shuts down when a previously installed custom packages are not specified in subsequent commands. For example:

1. Run: `idpbuilder create --package-dir examples/basic/package1`. 
2. Run: `idpbuilder create --package-dir examples/basic/package2`. This never exits.
3. If you do `./idpbuilder create --package-dir examples/basic/package2 --package-dir examples/basic/package1`, it shuts down as expected.

This is because the annotation value we use to track CLI invocation time is updated for specified packages only. So when you run the second command, the annotations for the packages in `examples/basic/package2` are updated but not for the existing packages in the first package. When we check if we need to shutdown, we look at all package objects in the cluster. 

So we either need to:
- Ignore objects that do not have expected cli start time annotation value. OR
- Update all existing objects' annotation values.  OR
- Remove unspecified packages.

I think it comes down to how we understand what the intent is when a user runs the second command. Do you care about the packages from the first command? If no, do you want us to remove them? 