### PR TITLE
make the serving port for idpBuilder configurable

### DIFF
--- a/examples/local-backup/kind.yaml
+++ b/examples/local-backup/kind.yaml
@@ -15,5 +15,5 @@ nodes:
       containerPath: /backup
   extraPortMappings:
   - containerPort: 443
-    hostPort: 8443
+    hostPort: {{ .Port }}
     protocol: TCP

--- a/examples/ref-implementation/README.md
+++ b/examples/ref-implementation/README.md
@@ -26,6 +26,8 @@ idpbuilder create --package-dir examples/ref-implementation
 
 This will take ~6 minutes for everything to come up. To track the progress, you can go to the [ArgoCD UI](https://argocd.cnoe.localtest.me:8443/applications).
 
+**_NOTE:_**: _This example assumes that you run the reference implementation with the default port configguration of 8443 for the idpBuilder. If you happen to configure a different port for the idpBuilder, the manifests in the reference example need to be updated and be configured with the new port. you can use the [replace-port.sh](replace-port.sh) to change the port as desired prior to applying the manifest as instructed in the command above._
+
 ### What was installed?
 
 1. **Argo Workflows** to enable workflow orchestrations.

--- a/examples/ref-implementation/replace-port.sh
+++ b/examples/ref-implementation/replace-port.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if the new port number is provided as an argument
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 NEW_PORT"
+    exit 1
+fi
+
+# Assign the first script argument to NEW_PORT
+NEW_PORT="$1"
+
+# Base directory to start from, "." means the current directory
+BASE_DIRECTORY="."
+
+# Find all .yaml files recursively starting from the base directory
+# and perform an in-place search and replace from 8443 to the new port
+find "$BASE_DIRECTORY" -type f -name "*.yaml" -exec sed -i '' "s/8443/${NEW_PORT}/g" {} +
+
+echo "Replacement complete. All occurrences of 8443 have been changed to ${NEW_PORT}."
+

--- a/hack/ingress-nginx/deployment-ingress-nginx.yaml
+++ b/hack/ingress-nginx/deployment-ingress-nginx.yaml
@@ -26,7 +26,7 @@ spec:
             - --controller-class=k8s.io/ingress-nginx
             - --ingress-class=nginx
             - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
-            - --validating-webhook=:8443
+            - --validating-webhook=:{{ .Port }}
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
             - --watch-ingress-without-class=true

--- a/hack/ingress-nginx/service-ingress-nginx.yaml
+++ b/hack/ingress-nginx/service-ingress-nginx.yaml
@@ -9,7 +9,7 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
     - appProtocol: https
-      name: https-8443
-      port: 8443
+      name: https-{{ .Port }}
+      port: {{ .Port }}
       protocol: TCP
       targetPort: https

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cnoe-io/idpbuilder/pkg/build"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
+	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -19,6 +20,7 @@ import (
 var (
 	// Flags
 	recreateCluster   bool
+	port              string
 	buildName         string
 	kubeVersion       string
 	extraPortsMapping string
@@ -37,6 +39,7 @@ var CreateCmd = &cobra.Command{
 func init() {
 	CreateCmd.PersistentFlags().BoolVar(&recreateCluster, "recreate", false, "Delete cluster first if it already exists.")
 	CreateCmd.PersistentFlags().StringVar(&buildName, "build-name", "localdev", "Name for build (Prefix for kind cluster name, pod names, etc).")
+	CreateCmd.PersistentFlags().StringVar(&port, "port", "8443", "Port number under which idpBuilder tools are accessible.")
 	CreateCmd.PersistentFlags().StringVar(&kubeVersion, "kube-version", "v1.27.3", "Version of the kind kubernetes cluster to create.")
 	CreateCmd.PersistentFlags().StringVar(&extraPortsMapping, "extra-ports", "", "List of extra ports to expose on the docker container and kubernetes cluster as nodePort (e.g. \"22:32222,9090:39090,etc\").")
 	CreateCmd.PersistentFlags().StringVar(&kindConfigPath, "kind-config", "", "Path of the kind config file to be used instead of the default.")
@@ -78,14 +81,14 @@ func create(cmd *cobra.Command, args []string) error {
 		exitOnSync = !noExit
 	}
 
-	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping, absDirPaths, exitOnSync, k8s.GetScheme(), ctxCancel)
+	b := build.NewBuild(buildName, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping, util.TemplateConfig{Port: port}, absDirPaths, exitOnSync, k8s.GetScheme(), ctxCancel)
 
 	if err := b.Run(ctx, recreateCluster); err != nil {
 		return err
 	}
 
 	fmt.Print("\n\n########################### Finished Creating IDP Successfully! ############################\n\n\n")
-	fmt.Print("Can Access ArgoCD at https://argocd.cnoe.localtest.me:8443/\nUsername: admin\n")
+	fmt.Printf("Can Access ArgoCD at https://argocd.cnoe.localtest.me:%s/\nUsername: admin\n", port)
 	fmt.Print(`Password can be retrieved by running: kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`, "\n")
 
 	return nil

--- a/pkg/controllers/crd.go
+++ b/pkg/controllers/crd.go
@@ -19,8 +19,8 @@ import (
 //go:embed resources/*.yaml
 var crdFS embed.FS
 
-func getK8sResources(scheme *runtime.Scheme) ([]client.Object, error) {
-	rawResources, err := util.ConvertFSToBytes(crdFS, "resources")
+func getK8sResources(scheme *runtime.Scheme, template interface{}) ([]client.Object, error) {
+	rawResources, err := util.ConvertFSToBytes(crdFS, "resources", template)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func EnsureCRD(ctx context.Context, scheme *runtime.Scheme, kubeClient client.Cl
 	return nil
 }
 
-func EnsureCRDs(ctx context.Context, scheme *runtime.Scheme, kubeClient client.Client) error {
-	installObjs, err := getK8sResources(scheme)
+func EnsureCRDs(ctx context.Context, scheme *runtime.Scheme, kubeClient client.Client, template interface{}) error {
+	installObjs, err := getK8sResources(scheme, template)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/gitrepository/controller.go
+++ b/pkg/controllers/gitrepository/controller.go
@@ -46,6 +46,7 @@ type RepositoryReconciler struct {
 	GiteaClientFunc GiteaClientFunc
 	Recorder        record.EventRecorder
 	Scheme          *runtime.Scheme
+	Config          util.TemplateConfig
 }
 
 func getRepositoryName(repo v1alpha1.GitRepository) string {
@@ -180,7 +181,7 @@ func (r *RepositoryReconciler) reconcileRepoContent(ctx context.Context, repo *v
 		return fmt.Errorf("cloning repo: %w", err)
 	}
 
-	err = writeRepoContents(repo, tempDir)
+	err = writeRepoContents(repo, tempDir, r.Config)
 	if err != nil {
 		return err
 	}
@@ -275,9 +276,9 @@ func (r *RepositoryReconciler) shouldProcess(repo v1alpha1.GitRepository) bool {
 	return true
 }
 
-func writeRepoContents(repo *v1alpha1.GitRepository, dstPath string) error {
+func writeRepoContents(repo *v1alpha1.GitRepository, dstPath string, template interface{}) error {
 	if repo.Spec.Source.EmbeddedAppName != "" {
-		resources, err := localbuild.GetEmbeddedRawInstallResources(repo.Spec.Source.EmbeddedAppName)
+		resources, err := localbuild.GetEmbeddedRawInstallResources(repo.Spec.Source.EmbeddedAppName, template)
 		if err != nil {
 			return fmt.Errorf("getting embedded resource; %w", err)
 		}

--- a/pkg/controllers/localbuild/argo.go
+++ b/pkg/controllers/localbuild/argo.go
@@ -17,8 +17,8 @@ const (
 	argocdNamespace string = "argocd"
 )
 
-func RawArgocdInstallResources() ([][]byte, error) {
-	return util.ConvertFSToBytes(installArgoFS, "resources/argo")
+func RawArgocdInstallResources(tmpl interface{}) ([][]byte, error) {
+	return util.ConvertFSToBytes(installArgoFS, "resources/argo", tmpl)
 }
 
 func (r *LocalbuildReconciler) ReconcileArgo(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) (ctrl.Result, error) {
@@ -47,7 +47,7 @@ func (r *LocalbuildReconciler) ReconcileArgo(ctx context.Context, req ctrl.Reque
 		skipReadinessCheck: true,
 	}
 
-	if result, err := argocd.Install(ctx, req, resource, r.Client, r.Scheme); err != nil {
+	if result, err := argocd.Install(ctx, req, resource, r.Client, r.Scheme, r.Config); err != nil {
 		return result, err
 	}
 

--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -11,7 +11,7 @@ func TestGetRawInstallResources(t *testing.T) {
 		resourceFS:   installArgoFS,
 		resourcePath: "resources/argo",
 	}
-	resources, err := e.rawInstallResources()
+	resources, err := e.rawInstallResources(struct{ Port string }{"8443"})
 	if err != nil {
 		t.Fatalf("GetRawInstallResources() error: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestGetK8sInstallResources(t *testing.T) {
 		resourceFS:   installArgoFS,
 		resourcePath: "resources/argo",
 	}
-	objs, err := e.installResources(k8s.GetScheme())
+	objs, err := e.installResources(k8s.GetScheme(), struct{ Port string }{"8443"})
 	if err != nil {
 		t.Fatalf("GetK8sInstallResources() error: %v", err)
 	}

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -37,6 +37,7 @@ type LocalbuildReconciler struct {
 	CancelFunc     context.CancelFunc
 	ExitOnSync     bool
 	shouldShutdown bool
+	Config         util.TemplateConfig
 }
 
 type subReconciler func(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) (ctrl.Result, error)
@@ -399,14 +400,14 @@ func getCustomPackageName(fileName, appName string) string {
 	return fmt.Sprintf("%s-%s", strings.ToLower(s[0]), appName)
 }
 
-func GetEmbeddedRawInstallResources(name string) ([][]byte, error) {
+func GetEmbeddedRawInstallResources(name string, template interface{}) ([][]byte, error) {
 	switch name {
 	case "argocd":
-		return RawArgocdInstallResources()
+		return RawArgocdInstallResources(template)
 	case "gitea":
-		return RawGiteaInstallResources()
+		return RawGiteaInstallResources(template)
 	case "nginx":
-		return RawNginxInstallResources()
+		return RawNginxInstallResources(template)
 	default:
 		return nil, fmt.Errorf("unsupported embedded app name %s", name)
 	}

--- a/pkg/controllers/localbuild/installer.go
+++ b/pkg/controllers/localbuild/installer.go
@@ -39,12 +39,12 @@ type EmbeddedInstallation struct {
 	resourceFS embed.FS
 }
 
-func (e *EmbeddedInstallation) rawInstallResources() ([][]byte, error) {
-	return util.ConvertFSToBytes(e.resourceFS, e.resourcePath)
+func (e *EmbeddedInstallation) rawInstallResources(template interface{}) ([][]byte, error) {
+	return util.ConvertFSToBytes(e.resourceFS, e.resourcePath, template)
 }
 
-func (e *EmbeddedInstallation) installResources(scheme *runtime.Scheme) ([]client.Object, error) {
-	rawResources, err := e.rawInstallResources()
+func (e *EmbeddedInstallation) installResources(scheme *runtime.Scheme, template interface{}) ([]client.Object, error) {
+	rawResources, err := e.rawInstallResources(template)
 	if err != nil {
 		return nil, err
 	}
@@ -60,11 +60,11 @@ func (e *EmbeddedInstallation) newNamespace(namespace string) *corev1.Namespace 
 	}
 }
 
-func (e *EmbeddedInstallation) Install(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild, cli client.Client, sc *runtime.Scheme) (ctrl.Result, error) {
+func (e *EmbeddedInstallation) Install(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild, cli client.Client, sc *runtime.Scheme, cfg util.TemplateConfig) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	nsClient := client.NewNamespacedClient(cli, e.namespace)
-	installObjs, err := e.installResources(sc)
+	installObjs, err := e.installResources(sc, cfg)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/localbuild/nginx.go
+++ b/pkg/controllers/localbuild/nginx.go
@@ -17,8 +17,8 @@ const (
 //go:embed resources/nginx/k8s/*
 var installNginxFS embed.FS
 
-func RawNginxInstallResources() ([][]byte, error) {
-	return util.ConvertFSToBytes(installNginxFS, "resources/nginx/k8s")
+func RawNginxInstallResources(tmpl interface{}) ([][]byte, error) {
+	return util.ConvertFSToBytes(installNginxFS, "resources/nginx/k8s", tmpl)
 }
 
 func (r *LocalbuildReconciler) ReconcileNginx(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) (ctrl.Result, error) {
@@ -36,7 +36,7 @@ func (r *LocalbuildReconciler) ReconcileNginx(ctx context.Context, req ctrl.Requ
 		},
 	}
 
-	if result, err := nginx.Install(ctx, req, resource, r.Client, r.Scheme); err != nil {
+	if result, err := nginx.Install(ctx, req, resource, r.Client, r.Scheme, r.Config); err != nil {
 		return result, err
 	}
 

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -28,7 +28,7 @@ stringData:
     ENABLE_PPROF=false
     HTTP_PORT=3000
     PROTOCOL=http
-    ROOT_URL=https://gitea.cnoe.localtest.me:8443
+    ROOT_URL=https://gitea.cnoe.localtest.me:{{ .Port }}
     SSH_DOMAIN=gitea.cnoe.localtest.me
     SSH_LISTEN_PORT=2222
     SSH_PORT=22

--- a/pkg/controllers/localbuild/resources/gitea/values.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/values.yaml
@@ -25,7 +25,7 @@ gitea:
       TYPE: level
     server:
       DOMAIN: gitea.cnoe.localtest.me
-      ROOT_URL: 'https://gitea.cnoe.localtest.me:8443'
+      ROOT_URL: 'https://gitea.cnoe.localtest.me:{{ .Port }}'
 
 service:
   ssh:

--- a/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
+++ b/pkg/controllers/localbuild/resources/nginx/k8s/ingress-nginx.yaml
@@ -352,8 +352,8 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
   - appProtocol: https
-    name: https-8443
-    port: 8443
+    name: https-{{ .Port }}
+    port: {{ .Port }}
     protocol: TCP
     targetPort: https
   - appProtocol: http
@@ -434,7 +434,7 @@ spec:
         - --controller-class=k8s.io/ingress-nginx
         - --ingress-class=nginx
         - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
-        - --validating-webhook=:8443
+        - --validating-webhook=:{{ .Port }}
         - --validating-webhook-certificate=/usr/local/certificates/cert
         - --validating-webhook-key=/usr/local/certificates/key
         - --watch-ingress-without-class=true
@@ -478,7 +478,7 @@ spec:
           hostPort: 443
           name: https
           protocol: TCP
-        - containerPort: 8443
+        - containerPort: {{ .Port }}
           name: webhook
           protocol: TCP
         readinessProbe:

--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/custompackage"
+	"github.com/cnoe-io/idpbuilder/pkg/util"
 
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/gitrepository"
 	"github.com/cnoe-io/idpbuilder/pkg/controllers/localbuild"
@@ -11,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error, ctxCancel context.CancelFunc, exitOnSync bool) error {
+func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error, ctxCancel context.CancelFunc, exitOnSync bool, cfg util.TemplateConfig) error {
 	log := log.FromContext(ctx)
 
 	// Run Localbuild controller
@@ -20,6 +21,7 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		Scheme:     mgr.GetScheme(),
 		ExitOnSync: exitOnSync,
 		CancelFunc: ctxCancel,
+		Config:     cfg,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create localbuild controller")
 		return err
@@ -30,6 +32,7 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		Scheme:          mgr.GetScheme(),
 		Recorder:        mgr.GetEventRecorderFor("gitrepository-controller"),
 		GiteaClientFunc: gitrepository.NewGiteaClient,
+		Config:          cfg,
 	}).SetupWithManager(mgr, nil)
 	if err != nil {
 		log.Error(err, "unable to create repo controller")

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -1,12 +1,14 @@
 package kind
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/cnoe-io/idpbuilder/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetConfig(t *testing.T) {
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "", util.TemplateConfig{})
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}
@@ -38,7 +40,7 @@ nodes:
 }
 
 func TestExtraPortMappings(t *testing.T) {
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222")
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222", util.TemplateConfig{})
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}

--- a/pkg/kind/resources/kind.yaml
+++ b/pkg/kind/resources/kind.yaml
@@ -13,7 +13,7 @@ nodes:
         node-labels: "ingress-ready=true"
   extraPortMappings:
   - containerPort: 443
-    hostPort: 8443
+    hostPort: {{ .Port }}
     protocol: TCP
   {{ range .ExtraPortsMapping }}- containerPort: {{ .ContainerPort }}
     hostPort: {{ .HostPort }}

--- a/pkg/util/build_config.go
+++ b/pkg/util/build_config.go
@@ -1,0 +1,5 @@
+package util
+
+type TemplateConfig struct {
+	Port string
+}

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -1,10 +1,12 @@
 package util
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"text/template"
 )
 
 func CopyDirectory(scrDir, dest string) error {
@@ -89,4 +91,20 @@ func CreateIfNotExists(dir string, perm os.FileMode) error {
 	}
 
 	return nil
+}
+
+func ApplyTemplate(in []byte, tmpl interface{}) ([]byte, error) {
+	t, err := template.New("template").Parse(string(in))
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the template with the file content and write the output to the destination file
+	ret := bytes.Buffer{}
+	err = t.Execute(&ret, tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret.Bytes(), nil
 }

--- a/pkg/util/fs.go
+++ b/pkg/util/fs.go
@@ -15,7 +15,7 @@ type FS interface {
 	ReadFile(name string) ([]byte, error)
 }
 
-func ConvertFSToBytes(inFS FS, name string) ([][]byte, error) {
+func ConvertFSToBytes(inFS FS, name string, tmpl interface{}) ([][]byte, error) {
 	d, err := inFS.ReadDir(name)
 	if err != nil {
 		return nil, err
@@ -28,8 +28,14 @@ func ConvertFSToBytes(inFS FS, name string) ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		rawResources = append(rawResources, rawResource)
+
+		if returnedRawResource, err := ApplyTemplate(rawResource, tmpl); err == nil {
+			rawResources = append(rawResources, returnedRawResource)
+		} else {
+			return nil, err
+		}
 	}
+
 	return rawResources, nil
 }
 


### PR DESCRIPTION
- add a --port flag to configure the default port
- add go templates directives to override embedded resource manifests
- template kind cluster config
- add a sample script to tweak the port for the reference example

closes #139 