### PR TITLE
reduce log messages

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -113,13 +113,13 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 		return err
 	}
 
-	setupLog.Info("Getting Kube config")
+	setupLog.V(1).Info("Getting Kube config")
 	kubeConfig, err := b.GetKubeConfig()
 	if err != nil {
 		return err
 	}
 
-	setupLog.Info("Getting Kube client")
+	setupLog.V(1).Info("Getting Kube client")
 	kubeClient, err := b.GetKubeClient(kubeConfig)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 		return err
 	}
 
-	setupLog.Info("Creating controller manager")
+	setupLog.V(1).Info("Creating controller manager")
 	// Create controller manager
 	mgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
 		Scheme: b.scheme,
@@ -143,7 +143,7 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 		return err
 	}
 
-	setupLog.Info("Running controllers")
+	setupLog.V(1).Info("Running controllers")
 	if err := b.RunControllers(ctx, mgr, managerExit); err != nil {
 		setupLog.Error(err, "Error running controllers")
 		return err

--- a/pkg/cmd/helpers/logger.go
+++ b/pkg/cmd/helpers/logger.go
@@ -21,9 +21,13 @@ func SetLogger() error {
 	if err != nil {
 		return err
 	}
+
 	slogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: l}))
+	kslogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: getKlogLevel(l)}))
 	logger := logr.FromSlogHandler(slogger.Handler())
-	klog.SetLogger(logger)
+	klogger := logr.FromSlogHandler(kslogger.Handler())
+
+	klog.SetLogger(klogger)
 	ctrl.SetLogger(logger)
 	return nil
 }
@@ -41,4 +45,12 @@ func getSlogLevel(s string) (slog.Level, error) {
 	default:
 		return slog.LevelDebug, fmt.Errorf("%s is not a valid log level", s)
 	}
+}
+
+// For end users, klog messages are mostly useless. We set it to error level unless debug logging is enabled.
+func getKlogLevel(l slog.Level) slog.Level {
+	if l < slog.LevelInfo {
+		return l
+	}
+	return slog.LevelError
 }

--- a/pkg/controllers/custompackage/controller.go
+++ b/pkg/controllers/custompackage/controller.go
@@ -43,7 +43,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	logger.Info("reconciling custom package", "name", req.Name, "namespace", req.Namespace)
+	logger.V(1).Info("reconciling custom package", "name", req.Name, "namespace", req.Namespace)
 	defer r.postProcessReconcile(ctx, req, &pkg)
 	result, err := r.reconcileCustomPackage(ctx, &pkg)
 	if err != nil {

--- a/pkg/controllers/custompackage/controller_test.go
+++ b/pkg/controllers/custompackage/controller_test.go
@@ -151,7 +151,6 @@ func TestReconcileCustomPkg(t *testing.T) {
 		}
 	}
 	time.Sleep(1 * time.Second)
-
 	// verify repo.
 	c := mgr.GetClient()
 	repo := v1alpha1.GitRepository{

--- a/pkg/controllers/gitrepository/controller.go
+++ b/pkg/controllers/gitrepository/controller.go
@@ -103,7 +103,7 @@ func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{Requeue: false}, nil
 	}
 
-	logger.Info("reconciling GitRepository", "name", req.Name, "namespace", req.Namespace)
+	logger.V(1).Info("reconciling GitRepository", "name", req.Name, "namespace", req.Namespace)
 	result, err := r.reconcileGitRepo(ctx, &gitRepo)
 	if err != nil {
 		r.Recorder.Event(&gitRepo, "Warning", "reconcile error", err.Error())
@@ -130,7 +130,7 @@ func (r *RepositoryReconciler) postProcessReconcile(ctx context.Context, req ctr
 
 func (r *RepositoryReconciler) reconcileGitRepo(ctx context.Context, repo *v1alpha1.GitRepository) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-	logger.Info("reconciling", "name", repo.Name, "dir", repo.Spec.Source)
+	logger.V(1).Info("reconciling", "name", repo.Name, "dir", repo.Spec.Source)
 	repo.Status.Synced = false
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -43,12 +43,12 @@ type LocalbuildReconciler struct {
 type subReconciler func(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) (ctrl.Result, error)
 
 func (r *LocalbuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
-	log.Info("Reconciling", "resource", req.NamespacedName)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling", "resource", req.NamespacedName)
 
 	var localBuild v1alpha1.Localbuild
 	if err := r.Get(ctx, req.NamespacedName, &localBuild); err != nil {
-		log.Error(err, "unable to fetch Resource")
+		logger.Error(err, "unable to fetch Resource")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
 		// on deleted requests.
@@ -94,7 +94,7 @@ func (r *LocalbuildReconciler) postProcessReconcile(ctx context.Context, req ctr
 }
 
 func (r *LocalbuildReconciler) ReconcileProjectNamespace(ctx context.Context, req ctrl.Request, resource *v1alpha1.Localbuild) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	nsResource := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,16 +102,16 @@ func (r *LocalbuildReconciler) ReconcileProjectNamespace(ctx context.Context, re
 		},
 	}
 
-	log.Info("Create or update namespace", "resource", nsResource)
+	logger.V(1).Info("Create or update namespace", "resource", nsResource)
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, nsResource, func() error {
 		if err := controllerutil.SetControllerReference(resource, nsResource, r.Scheme); err != nil {
-			log.Error(err, "Setting controller ref on namespace resource")
+			logger.Error(err, "Setting controller ref on namespace resource")
 			return err
 		}
 		return nil
 	})
 	if err != nil {
-		log.Error(err, "Create or update namespace resource")
+		logger.Error(err, "Create or update namespace resource")
 	}
 	return ctrl.Result{}, err
 }
@@ -157,7 +157,7 @@ func (r *LocalbuildReconciler) ReconcileArgoAppsWithGitea(ctx context.Context, r
 func (r *LocalbuildReconciler) reconcileEmbeddedApp(ctx context.Context, appName string, resource *v1alpha1.Localbuild) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	logger.Info("Ensuring embedded ArgoCD Application", "name", appName)
+	logger.V(1).Info("Ensuring embedded ArgoCD Application", "name", appName)
 	repo, err := r.reconcileGitRepo(ctx, resource, "embedded", appName, appName, "")
 
 	if err != nil {

--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -13,7 +13,7 @@ import (
 )
 
 func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error, ctxCancel context.CancelFunc, exitOnSync bool, cfg util.CorePackageTemplateConfig) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Run Localbuild controller
 	if err := (&localbuild.LocalbuildReconciler{
@@ -23,7 +23,7 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		CancelFunc: ctxCancel,
 		Config:     cfg,
 	}).SetupWithManager(mgr); err != nil {
-		log.Error(err, "unable to create localbuild controller")
+		logger.Error(err, "unable to create localbuild controller")
 		return err
 	}
 
@@ -35,7 +35,7 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		Config:          cfg,
 	}).SetupWithManager(mgr, nil)
 	if err != nil {
-		log.Error(err, "unable to create repo controller")
+		logger.Error(err, "unable to create repo controller")
 	}
 
 	err = (&custompackage.Reconciler{
@@ -44,14 +44,14 @@ func RunControllers(ctx context.Context, mgr manager.Manager, exitCh chan error,
 		Recorder: mgr.GetEventRecorderFor("custompackage-controller"),
 	}).SetupWithManager(mgr)
 	if err != nil {
-		log.Error(err, "unable to create custom package controller")
+		logger.Error(err, "unable to create custom package controller")
 	}
 
 	// Start our manager in another goroutine
-	log.Info("starting manager")
+	logger.V(1).Info("starting manager")
 	go func() {
 		if err := mgr.Start(ctx); err != nil {
-			log.Error(err, "problem running manager")
+			logger.Error(err, "problem running manager")
 			exitCh <- err
 		}
 		exitCh <- nil


### PR DESCRIPTION
Setting some messages to be logged at debug level instead of all being at info level. I don't think they are useful for end users unless they run into a problem.