### PR TITLE
Enable gitea oci registry

### DIFF
--- a/hack/gitea/generate-manifests.sh
+++ b/hack/gitea/generate-manifests.sh
@@ -3,7 +3,7 @@ set -e
 
 INSTALL_YAML="pkg/controllers/localbuild/resources/gitea/k8s/install.yaml"
 GITEA_DIR="./hack/gitea"
-CHART_VERSION="10.1.3"
+CHART_VERSION="10.1.4"
 
 echo "# GITEA INSTALL RESOURCES" >${INSTALL_YAML}
 echo "# This file is auto-generated with 'hack/gitea/generate-manifests.sh'" >>${INSTALL_YAML}

--- a/hack/gitea/generate-manifests.sh
+++ b/hack/gitea/generate-manifests.sh
@@ -3,7 +3,7 @@ set -e
 
 INSTALL_YAML="pkg/controllers/localbuild/resources/gitea/k8s/install.yaml"
 GITEA_DIR="./hack/gitea"
-CHART_VERSION="9.5.1"
+CHART_VERSION="10.1.3"
 
 echo "# GITEA INSTALL RESOURCES" >${INSTALL_YAML}
 echo "# This file is auto-generated with 'hack/gitea/generate-manifests.sh'" >>${INSTALL_YAML}

--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -35,7 +35,9 @@ service:
     externalTrafficPolicy: Local
 
 ingress:
+  # NOTE: The ingress is generated in a later step for path based routing feature See: hack/argo-cd/generate-manifests.sh
   enabled: false
 
 image:
   pullPolicy: "IfNotPresent"
+  rootless: true

--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -40,4 +40,7 @@ ingress:
 
 image:
   pullPolicy: "IfNotPresent"
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "1.22.0"
+  # Adds -rootless suffix to image name
   rootless: true

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -6,12 +6,12 @@ kind: Secret
 metadata:
   name: my-gitea-inline-config
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -48,12 +48,12 @@ kind: Secret
 metadata:
   name: my-gitea
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -220,12 +220,12 @@ kind: Secret
 metadata:
   name: my-gitea-init
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -321,10 +321,13 @@ metadata:
   namespace: gitea
   annotations:
     helm.sh/resource-policy: keep
+  labels:
+    {}
 spec:
   accessModes:
     - ReadWriteOnce
   volumeMode: Filesystem
+  
   resources:
     requests:
       storage: 5Gi
@@ -335,12 +338,12 @@ kind: Service
 metadata:
   name: my-gitea-http
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -361,12 +364,12 @@ kind: Service
 metadata:
   name: my-gitea-ssh
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -390,12 +393,12 @@ metadata:
   name: my-gitea
   annotations:
   labels:
-    helm.sh/chart: gitea-10.1.3
+    helm.sh/chart: gitea-10.1.4
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.21.7-cnoe-patches"
-    version: "1.21.7-cnoe-patches"
+    app.kubernetes.io/version: "1.22.0"
+    version: "1.22.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -411,14 +414,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc8a742ffa47df3321e68788f9069f104e7e3f7448767e885fb2a4cc85a1510e
+        checksum/config: 9b7b5c7586d38c5c0feeb0c69191c8fbdb6bfac258ad125dd26b9a125ed67173
       labels:
-        helm.sh/chart: gitea-10.1.3
+        helm.sh/chart: gitea-10.1.4
         app: gitea
         app.kubernetes.io/name: gitea
         app.kubernetes.io/instance: my-gitea
-        app.kubernetes.io/version: "1.21.7-cnoe-patches"
-        version: "1.21.7-cnoe-patches"
+        app.kubernetes.io/version: "1.22.0"
+        version: "1.22.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -6,21 +6,25 @@ kind: Secret
 metadata:
   name: my-gitea-inline-config
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
   _generals_: ""
-  cache: ADAPTER=memory
+  cache: |-
+    ADAPTER=memory
+    HOST=
   database: DB_TYPE=sqlite3
   indexer: ISSUE_INDEXER_TYPE=db
   metrics: ENABLED=false
-  queue: TYPE=level
+  queue: |-
+    CONN_STR=
+    TYPE=level
   repository: ROOT=/data/git/gitea-repositories
   security: INSTALL_LOCK=true
   server: |-
@@ -44,12 +48,12 @@ kind: Secret
 metadata:
   name: my-gitea
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -181,7 +185,7 @@ stringData:
     }
     
     # save existing envs prior to script execution. Necessary to keep order of preexisting and custom envs
-    env | (grep GITEA || [[ $? == 1 ]]) > /tmp/existing-envs
+    env | (grep -e '^GITEA__' || [[ $? == 1 ]]) > /tmp/existing-envs
     
     # MUST BE CALLED BEFORE OTHER CONFIGURATION
     env2ini::generate_initial_secrets
@@ -216,12 +220,12 @@ kind: Secret
 metadata:
   name: my-gitea-init
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 stringData:
@@ -260,7 +264,28 @@ stringData:
       exit 1
     }
     function configure_admin_user() {
-      local ACCOUNT_ID=$(gitea admin user list --admin | grep -e "\s\+${GITEA_ADMIN_USERNAME}\s\+" | awk -F " " "{printf \$1}")
+      local full_admin_list=$(gitea admin user list --admin)
+      local actual_user_table=''
+
+      # We might have distorted output due to warning logs, so we have to detect the actual user table by its headline and trim output above that line
+      local regex="(.*)(ID\s+Username\s+Email\s+IsActive.*)"
+      if [[ "${full_admin_list}" =~ $regex ]]; then
+        actual_user_table=$(echo "${BASH_REMATCH[2]}" | tail -n+2) # tail'ing to drop the table headline
+      else
+        # This code block should never be reached, as long as the output table header remains the same.
+        # If this code block is reached, the regex doesn't match anymore and we probably have to adjust this script.
+
+        echo "ERROR: 'configure_admin_user' was not able to determine the current list of admin users."
+        echo "       Please review the output of 'gitea admin user list --admin' shown below."
+        echo "       If you think it is an issue with the Helm Chart provisioning, file an issue at https://gitea.com/gitea/helm-chart/issues."
+        echo "DEBUG: Output of 'gitea admin user list --admin'"
+        echo "--"
+        echo "${full_admin_list}"
+        echo "--"
+        exit 1
+      fi
+
+      local ACCOUNT_ID=$(echo "${actual_user_table}" | grep -E "\s+${GITEA_ADMIN_USERNAME}\s+" | awk -F " " "{printf \$1}")
       if [[ -z "${ACCOUNT_ID}" ]]; then
         echo "No admin user '${GITEA_ADMIN_USERNAME}' found. Creating now..."
         gitea admin user create --admin --username "${GITEA_ADMIN_USERNAME}" --password "${GITEA_ADMIN_PASSWORD}" --email "gitea@local.domain" --must-change-password=false
@@ -310,12 +335,12 @@ kind: Service
 metadata:
   name: my-gitea-http
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -336,12 +361,12 @@ kind: Service
 metadata:
   name: my-gitea-ssh
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -365,12 +390,12 @@ metadata:
   name: my-gitea
   annotations:
   labels:
-    helm.sh/chart: gitea-9.5.1
+    helm.sh/chart: gitea-10.1.3
     app: gitea
     app.kubernetes.io/name: gitea
     app.kubernetes.io/instance: my-gitea
-    app.kubernetes.io/version: "1.20.5"
-    version: "1.20.5"
+    app.kubernetes.io/version: "1.21.7-cnoe-patches"
+    version: "1.21.7-cnoe-patches"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -386,14 +411,14 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a727070bdf60a2bb53744cb0893234188ca3917339f231a79454d661720f50b0
+        checksum/config: dc8a742ffa47df3321e68788f9069f104e7e3f7448767e885fb2a4cc85a1510e
       labels:
-        helm.sh/chart: gitea-9.5.1
+        helm.sh/chart: gitea-10.1.3
         app: gitea
         app.kubernetes.io/name: gitea
         app.kubernetes.io/instance: my-gitea
-        app.kubernetes.io/version: "1.20.5"
-        version: "1.20.5"
+        app.kubernetes.io/version: "1.21.7-cnoe-patches"
+        version: "1.21.7-cnoe-patches"
         app.kubernetes.io/managed-by: Helm
     spec:
       
@@ -401,7 +426,7 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: init-directories
-          image: "gitea/gitea:1.20.5-rootless"
+          image: "gitea/gitea:1.22.0-rootless"
           imagePullPolicy: IfNotPresent
           command: ["/usr/sbin/init_directory_structure.sh"]
           env:
@@ -429,7 +454,7 @@ spec:
               cpu: 100m
               memory: 128Mi
         - name: init-app-ini
-          image: "gitea/gitea:1.20.5-rootless"
+          image: "gitea/gitea:1.22.0-rootless"
           imagePullPolicy: IfNotPresent
           command: ["/usr/sbin/config_environment.sh"]
           env:
@@ -459,7 +484,7 @@ spec:
               cpu: 100m
               memory: 128Mi
         - name: configure-gitea
-          image: "gitea/gitea:1.20.5-rootless"
+          image: "gitea/gitea:1.22.0-rootless"
           command: ["/usr/sbin/configure_gitea.sh"]
           imagePullPolicy: IfNotPresent
           securityContext:
@@ -501,7 +526,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: gitea
-          image: "gitea/gitea:1.20.5-rootless"
+          image: "gitea/gitea:1.22.0-rootless"
           imagePullPolicy: IfNotPresent
           env:
             # SSH Port values have to be set here as well for openssh configuration

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -45,7 +45,12 @@ nodes:
   - containerPort: 443
     hostPort: 8443
     protocol: TCP
-  `
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.cnoe.localtest.me:8443"]
+    endpoint = ["https://gitea.cnoe.localtest.me"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."gitea.cnoe.localtest.me".tls]
+    insecure_skip_verify = true`
 	assert.YAMLEq(t, expectConfig, string(cfg))
 }
 
@@ -81,7 +86,13 @@ nodes:
     protocol: TCP
   - containerPort: 32222
     hostPort: 22
-    protocol: TCP`
+    protocol: TCP
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.cnoe.localtest.me:8443"]
+    endpoint = ["https://gitea.cnoe.localtest.me"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."gitea.cnoe.localtest.me".tls]
+    insecure_skip_verify = true`
 
 	assert.YAMLEq(t, expectConfig, string(cfg))
 }

--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -19,3 +19,9 @@ nodes:
     hostPort: {{ .HostPort }}
     protocol: TCP
   {{ end }}
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.cnoe.localtest.me:8443"]
+    endpoint = ["https://gitea.cnoe.localtest.me"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."gitea.cnoe.localtest.me".tls]
+    insecure_skip_verify = true


### PR DESCRIPTION
This is now working with the following patch for gitea: https://github.com/jessesanford/gitea/blob/c2fffabcd5122d258360d4443b6e583fc62e28f1/routers/api/packages/container/container.go#L119-L131

We need to decide if we want to use this forked version temporarily while we shape a PR for upstream or continue to use an additional registry. @nimakaviani @nabuskey @greghaynes wdyt?