### PR TITLE
Allow other KinD providers to work

### DIFF
--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -99,7 +99,11 @@ func (c *Cluster) getConfig() ([]byte, error) {
 }
 
 func NewCluster(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, cfg util.CorePackageTemplateConfig) (*Cluster, error) {
-	provider := cluster.NewProvider(cluster.ProviderWithDocker())
+	detectOpt, err := cluster.DetectNodeProvider()
+	if err != nil {
+		return nil, err
+	}
+	provider := cluster.NewProvider(detectOpt)
 
 	return &Cluster{
 		provider:          provider,


### PR DESCRIPTION
When asking KinD for a provider, use the detection option instead of forcing it to the Docker provider.

This allows the new capability in KinD to use nerdctl or finch to work properly with idpbuilder.