### PR TITLE
add labels to expose keycloak secrets

### DIFF
--- a/examples/ref-implementation/keycloak/manifests/secret-gen.yaml
+++ b/examples/ref-implementation/keycloak/manifests/secret-gen.yaml
@@ -21,6 +21,10 @@ spec:
   target:
     name: keycloak-config
     template:
+      metadata:
+        labels:
+          cnoe.io/cli-secret: "true"
+          cnoe.io/package-name: keycloak
       engineVersion: v2
       data:
         KEYCLOAK_ADMIN_PASSWORD: "{{.KEYCLOAK_ADMIN_PASSWORD}}"


### PR DESCRIPTION
add labels to expose ref-implementation credentials when calling `get secrets`