### PR TITLE
Fix Backstage labels for basic backstage template

### DIFF
--- a/examples/ref-implementation/backstage-templates/entities/basic/skeleton/manifests/deployment.yaml
+++ b/examples/ref-implementation/backstage-templates/entities/basic/skeleton/manifests/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         app: nginx
+        entity-id: ${{values.name}}
     spec:
       containers:
         - name: nginx


### PR DESCRIPTION
When deploying the reference implementation and then creating a Backstage component from the `basic` template, the Kubernetes tab would only show the deployment, but no pod information due to the missing `entity-id` label on the deployment's `spec.template.metadata` object.