### PR TITLE
Improve doc: container engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ This can be useful in several ways:
 * Use within CI to perform integration testing.
 * Use as a local development environment for IDP engineers.
 
+## Prerequisites
+
+A container engine is needed locally such as:
+
+- [Docker desktop](https://www.docker.com/get-started/)
+- [Podman desktop](https://podman-desktop.io/)
+
+**Warning**: idpbuilder can only create a cluster using podman installed as [rootful](https://docs.podman.io/en/latest/markdown/podman-machine-set.1.html#rootful). The rootless mode will raise an error `Error: running kind with rootless provider requires setting systemd property "Delegate=yes", see https://kind.sigs.k8s.io/docs/user/rootless/`.
+
+**Note**: Set the `DOCKER_HOST` env var properly for `podman` to let idpbuilder to talk with the engine (e.g  export DOCKER_HOST="unix:///var/run/docker.sock")
+
 ## Quickstart
 
 ### Download and install the idpbuilder

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ This can be useful in several ways:
 
 A container engine is needed locally such as:
 
-- [Docker desktop](https://www.docker.com/get-started/)
-- [Podman desktop](https://podman-desktop.io/)
+| Name                                                  | Supported | Remark                                                                                                                              |
+|-------------------------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
+| [Docker desktop](https://www.docker.com/get-started/) | Yes       |                                                                                                                                     |
+| [Podman desktop](https://podman-desktop.io/)          | No        | idpbuilder can create a cluster using podman [rootful](https://docs.podman.io/en/latest/markdown/podman-machine-set.1.html#rootful) | 
 
-**Warning**: idpbuilder can only create a cluster using podman installed as [rootful](https://docs.podman.io/en/latest/markdown/podman-machine-set.1.html#rootful). The rootless mode will raise an error `Error: running kind with rootless provider requires setting systemd property "Delegate=yes", see https://kind.sigs.k8s.io/docs/user/rootless/`.
 
-**Note**: Set the `DOCKER_HOST` env var properly for `podman` to let idpbuilder to talk with the engine (e.g  export DOCKER_HOST="unix:///var/run/docker.sock")
+**Note**: Set the `DOCKER_HOST` env var property using `podman` to let idpbuilder to talk with the engine (e.g  export DOCKER_HOST="unix:///var/run/docker.sock")
 
 ## Quickstart
 


### PR DESCRIPTION
- Include a prerequisites section covering the container engines. 
- Add a warning and note about podman usage
- See: #214 