### PR TITLE
Updating `ReadMe` documentation for Backstage Terraform Integrations

### DIFF
--- a/examples/terraform-integrations/README.md
+++ b/examples/terraform-integrations/README.md
@@ -11,4 +11,4 @@ idpbuilder create \
   --package-dir examples/terraform-integrations
 ```
 
-As you see above, this add-on to `idpbuilder` has a dependency to the [reference implementation](../ref-implementation/). This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/). Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.```
+As you see above, this add-on to `idpbuilder` has a dependency to the [reference implementation](../ref-implementation/). This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/). Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.

--- a/examples/terraform-integrations/README.md
+++ b/examples/terraform-integrations/README.md
@@ -1,6 +1,6 @@
 # Terraform Integrations for Backstage
 
-IDP builder is now experimentally extensible to launch custom terraform patterns using package extensions. This is an experimental effort allowing the users of the `idpBuilder` to run terraform modules using the tooling in place.
+`idpBuilder` is now experimentally extensible to launch custom terraform patterns using package extensions. This is an experimental effort allowing the users of the `idpBuilder` to run terraform modules using the tooling in place.
 
 Please use the below command to deploy an IDP reference implementation with an Argo application for terraform integrations with few sample patterns we have built:
 

--- a/examples/terraform-integrations/README.md
+++ b/examples/terraform-integrations/README.md
@@ -1,13 +1,14 @@
 # Terraform Integrations for Backstage
 
-This is an experimental effort allowing the users of the idpBuilder to run terraform modules using the tooling in place.
+IDP builder is now experimentally extensible to launch custom terraform patterns using package extensions. This is an experimental effort allowing the users of the `idpBuilder` to run terraform modules using the tooling in place.
 
-This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/).
-Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.
+Please use the below command to deploy an IDP reference implementation with an Argo application for terraform integrations with few sample patterns we have built:
 
-This add-on has a dependency to the [reference implementation][../ref-implementation/]. In order to enable the add-on with 
-idpBuilder run the following:
-
-``` 
-./idpbuilder create --use-path-routing --package-dir examples/ref-implementation --package-dir examples/terraform-integrations 
+```bash
+idpbuilder create \
+  --use-path-routing \
+  --package-dir examples/ref-implementation \
+  --package-dir examples/terraform-integrations
 ```
+
+As you see above, this add-on to `idpbuilder` has a dependency to the [reference implementation][../ref-implementation/]. This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/). Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.

--- a/examples/terraform-integrations/README.md
+++ b/examples/terraform-integrations/README.md
@@ -11,4 +11,4 @@ idpbuilder create \
   --package-dir examples/terraform-integrations
 ```
 
-As you see above, this add-on to `idpbuilder` has a dependency to the [reference implementation][../ref-implementation/]. This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/). Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.
+As you see above, this add-on to `idpbuilder` has a dependency to the [reference implementation](../ref-implementation/). This stack add-on goes together with the work done under [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/). Once the add-on is enabled, the user will need to follow the setup discussed in the [backstage-terraform-integrations](https://github.com/cnoe-io/backstage-terraform-integrations/) repo for the remainder of the configuration, and terraform integrations should work.```


### PR DESCRIPTION
Updating `ReadMe` documentation for Backstage Terraform Integrations to support package integrations with [Backstage Terraform Integrations](https://github.com/cnoe-io/backstage-terraform-integrations/tree/main) repo.