### PR TITLE
AWS CLI Support to Dev Containers for Backstage Integrations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.21"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/aws-cli:1": {}
   },
   "postCreateCommand": ".devcontainer/postCreateCommand.sh",
   "workspaceFolder": "/home/vscode/idpbuilder",


### PR DESCRIPTION
This PR is to add AWS CLI Support for Dev Containers . This support is required to be baked in with Dev Containers to support backstage integrations like [terraform backstage integrations](https://github.com/cnoe-io/backstage-terraform-integrations) and others coming soon.