### PR TITLE
fix: rename gitea secret for better description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,9 @@ idpbuilder get secrets
 
 As described in the main readme file, the above command is equivalent to running:
 ```bash
-kubectl get secrets -n gitea gitea-credential -o go-template='{{ range $key, $value := .data }}{{ printf "%s: %s\n" $key ($value | base64decode) }}{{ end }}'
+kubectl -n argocd get secret argocd-initial-admin-secret
+kubectl get secrets -n gitea gitea-admin-secret
+kubectl get secrets -A -l cnoe.io/cli-secret=true
 ```
 
 All ArgoCD applications should be synced and healthy. You can check them in the UI or 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,9 @@ idpbuilder get secrets
 ```
 
 As described in the main readme file, the above command is equivalent to running:
+```bash
+kubectl get secrets -n gitea gitea-credential -o go-template='{{ range $key, $value := .data }}{{ printf "%s: %s\n" $key ($value | base64decode) }}{{ end }}'
+```
 
 All ArgoCD applications should be synced and healthy. You can check them in the UI or 
 

--- a/examples/ref-implementation/backstage/manifests/install.yaml
+++ b/examples/ref-implementation/backstage/manifests/install.yaml
@@ -420,11 +420,11 @@ spec:
   data:
     - secretKey: GITEA_USERNAME
       remoteRef:
-        key: gitea-admin-secret
+        key: gitea-credential
         property: username
     - secretKey: GITEA_PASSWORD
       remoteRef:
-        key: gitea-admin-secret
+        key: gitea-credential
         property: password
 ---
 apiVersion: networking.k8s.io/v1

--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -14,7 +14,7 @@ test:
 
 gitea:
   admin:
-    existingSecret: gitea-admin-secret
+    existingSecret: gitea-credential
   config:
     database:
       DB_TYPE: sqlite3

--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -40,7 +40,7 @@ var SecretsCmd = &cobra.Command{
 // well known secrets that are part of the core packages
 var corePkgSecrets = map[string][]string{
 	"argocd": []string{"argocd-initial-admin-secret"},
-	"gitea":  []string{"gitea-admin-secret"},
+	"gitea":  []string{"gitea-credential"},
 }
 
 type TemplateData struct {

--- a/pkg/cmd/get/secrets_test.go
+++ b/pkg/cmd/get/secrets_test.go
@@ -56,7 +56,7 @@ func TestPrintPackageSecrets(t *testing.T) {
 			listLabelSelector: []labels.Selector{selector("abc")},
 			getKeys: []client.ObjectKey{
 				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-admin-secret", Namespace: "gitea"},
+				{Name: "gitea-credential", Namespace: "gitea"},
 			},
 		},
 		{
@@ -64,7 +64,7 @@ func TestPrintPackageSecrets(t *testing.T) {
 			packages: []string{"argocd", "gitea"},
 			getKeys: []client.ObjectKey{
 				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-admin-secret", Namespace: "gitea"},
+				{Name: "gitea-credential", Namespace: "gitea"},
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestPrintAllPackageSecrets(t *testing.T) {
 			listLabelSelector: []labels.Selector{labels.NewSelector().Add(*r)},
 			getKeys: []client.ObjectKey{
 				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-admin-secret", Namespace: "gitea"},
+				{Name: "gitea-credential", Namespace: "gitea"},
 			},
 		},
 	}

--- a/pkg/controllers/localbuild/gitea.go
+++ b/pkg/controllers/localbuild/gitea.go
@@ -19,7 +19,7 @@ import (
 const (
 	// hardcoded values from what we have in the yaml installation file.
 	giteaNamespace   = "gitea"
-	giteaAdminSecret = "gitea-admin-secret"
+	giteaAdminSecret = "gitea-credential"
 	// this is the URL accessible outside cluster. resolves to localhost
 	giteaIngressURL = "%s://gitea.cnoe.localtest.me:%s"
 	// this is the URL accessible within cluster for ArgoCD to fetch resources.

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -479,12 +479,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key:  username
-                  name: gitea-admin-secret
+                  name: gitea-credential
             - name: GITEA_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key:  password
-                  name: gitea-admin-secret
+                  name: gitea-credential
           volumeMounts:
             - name: init
               mountPath: /usr/sbin


### PR DESCRIPTION
partially fixes #216

This only covers the gitea secret renaming, as apparently the argocd one is generated by argo on installation, and is hardcoded to `argocd-initial-admin-secret`.

See here: https://github.com/argoproj/argo-cd/blob/0f11dfb5961361807962aafc68b11426b8a47490/cmd/argocd/commands/admin/initial_password.go#L16

There's some world where we could replicate the secret into one with a name we like better, but that sounds like a recipe for confusion.