### PR TITLE
add argocd admin username

### DIFF
--- a/pkg/cmd/get/secrets_test.go
+++ b/pkg/cmd/get/secrets_test.go
@@ -55,23 +55,23 @@ func TestPrintPackageSecrets(t *testing.T) {
 			packages:          []string{"argocd", "gitea", "abc"},
 			listLabelSelector: []labels.Selector{selector("abc")},
 			getKeys: []client.ObjectKey{
-				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-credential", Namespace: "gitea"},
+				{Name: argoCDInitialAdminSecretName, Namespace: "argocd"},
+				{Name: giteaAdminSecretName, Namespace: "gitea"},
 			},
 		},
 		{
 			err:      nil,
 			packages: []string{"argocd", "gitea"},
 			getKeys: []client.ObjectKey{
-				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-credential", Namespace: "gitea"},
+				{Name: argoCDInitialAdminSecretName, Namespace: "argocd"},
+				{Name: giteaAdminSecretName, Namespace: "gitea"},
 			},
 		},
 		{
 			err:      nil,
 			packages: []string{"argocd"},
 			getKeys: []client.ObjectKey{
-				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
+				{Name: argoCDInitialAdminSecretName, Namespace: "argocd"},
 			},
 		},
 	}
@@ -109,8 +109,8 @@ func TestPrintAllPackageSecrets(t *testing.T) {
 			err:               nil,
 			listLabelSelector: []labels.Selector{labels.NewSelector().Add(*r)},
 			getKeys: []client.ObjectKey{
-				{Name: "argocd-initial-admin-secret", Namespace: "argocd"},
-				{Name: "gitea-credential", Namespace: "gitea"},
+				{Name: argoCDInitialAdminSecretName, Namespace: "argocd"},
+				{Name: giteaAdminSecretName, Namespace: "gitea"},
 			},
 		},
 	}


### PR DESCRIPTION
Adds argocd admin username to the get secrets command as mentioned in https://github.com/cnoe-io/idpbuilder/issues/216

```
./idpbuilder get secrets -p argocd
---------------------------
Name: argocd-initial-admin-secret
Namespace: argocd
Data:
  password : abc
  username : admin
```