### PR TITLE
enable serverside apply for tf-controller install

### DIFF
--- a/examples/terraform-integrations/tofu-controller.yaml
+++ b/examples/terraform-integrations/tofu-controller.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: 'https://flux-iac.github.io/tofu-controller'
-    targetRevision: v0.15.0
+    targetRevision: v0.15.1
     helm:
       releaseName: tf-controller
       values: |
@@ -30,3 +30,4 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
Fixes `The ConfigMap is invalid: metadata.annotations: Too long` issue when installing the tf-controller.
Also bumps the version of the tofu controller

The problem is discussed in details here: https://github.com/argoproj/argo-cd/issues/820 and the issue suggests to use `ServerSideApply=true` to skip the use of Kubectl when applying resources.

/cc @elamaran11 