### PR TITLE
Add localstack as addon package

### DIFF
--- a/examples/localstack-integration/README.md
+++ b/examples/localstack-integration/README.md
@@ -1,0 +1,17 @@
+# Localstack Integration
+
+Please use the below command to deploy an IDP reference implementation with an Argo application that adds Localstack, as well as integrating with Crossplane.
+
+```bash
+idpbuilder create \
+  --use-path-routing \
+  --package-dir examples/ref-implementation \
+  --package-dir examples/localstack-integration
+```
+
+As you see above, this add-on to `idpbuilder` has a dependency on the [reference implementation](../ref-implementation/). This command primarily does the following:
+
+1. Installs `localstack` helmchart as an `argo` application.
+2. Adds localstack crossplane ProviderConfig, targetting localstack
+
+Once the custom package is installed, localstack can be used from the backstage template `app-with-aws-resources`, by changing the `providerConfigName` during the bucket configuration page from `default` to `localstack`.

--- a/examples/localstack-integration/crossplane-provider-localstack.yaml
+++ b/examples/localstack-integration/crossplane-provider-localstack.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crossplane-provider-localstack
+  namespace: argocd
+  labels:
+    example: localstack-integration
+spec:
+  project: default
+  source:
+    repoURL: cnoe://crossplane-provider-localstack
+    targetRevision: HEAD
+    path: "."
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: crossplane-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/examples/localstack-integration/crossplane-provider-localstack/provider-config-localstack.yaml
+++ b/examples/localstack-integration/crossplane-provider-localstack/provider-config-localstack.yaml
@@ -1,0 +1,19 @@
+apiVersion: aws.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: localstack
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: local-secret
+      key: creds
+  endpoint:
+    hostnameImmutable: true
+    url:
+      type: Static
+      static: http://localstack.localstack.svc.cluster.local:4566

--- a/examples/localstack-integration/localstack.yaml
+++ b/examples/localstack-integration/localstack.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: localstack
+  namespace: argocd
+  labels:
+    example: localstack-integration
+spec:
+  project: default
+  source:
+    repoURL: https://localstack.github.io/helm-charts
+    targetRevision: 0.6.12
+    chart: localstack
+    helm:
+      releaseName: localstack
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: localstack
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
This adds localstack as an addon to the ref implemention, which involves the following:

    Install localstack as argo application
    Add a new Crossplane ProviderConfig for localstack

I already attempted to add the same directly to the ref impl [here](https://github.com/cnoe-io/idpbuilder/pull/248), but there were lots of cross-cutting concerns there. This is more of a drop-in, although doesn't integrate quite as much.

I think this should be much more acceptable, despite the minor UX downsides.