### PR TITLE
add configuration steps to create a brew release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,12 @@ jobs:
       - name: build
         run: |
           OUT_FILE=/tmp/idpbuilder make build
+      - name: Generate a homebrew tap update token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CNOE_HOMEBREW_APP_ID }}
+          private-key: ${{ secrets.CNOE_HOMEBREW_PRIVATE_KEY }}
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         id: run-goreleaser
@@ -30,3 +36,4 @@ jobs:
           args: release --clean --timeout 30m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,21 @@ builds:
     ignore:
       - goos: linux
         goarch: '386'
+brews:
+  - name: idpbuilder
+    homepage: "https://cnoe.io"
+    repository:
+      owner: nimakaviani
+      name: homebrew-cnoe
+      token: "{{ .Env.HOMEBREW_TOKEN }}"
+    commit_author:
+      name: "GoReleaser"
+      email: "noreply@goreleaser.com"
+    directory: formula
+    install: |
+      bin.install "idpbuilder"
+    test: |
+      system "#{bin}/idpbuilder --version"
 archives:
   - format: tar.gz
     name_template: >-


### PR DESCRIPTION
creates the homebrew formula for idpbuilder

Theoretically everything should work but kinda tricky to test this on the actual repo, since we need to cut a release. we can give it a go after it is reviewed and merged.