### PR TITLE
remove problematic special chars for bash

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,7 +17,7 @@ import (
 const (
 	chars           = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	digits          = "0123456789"
-	specialChars    = `!"#$%&'()*+,-./:;<=>?@[\\]^_{|}~`
+	specialChars    = `!#$%&'()*+,-./:;<=>?@[]^_{|}~`
 	passwordLength  = 40
 	numSpecialChars = 3
 	numDigits       = 3


### PR DESCRIPTION
When using idpbuilder with bash, the gitea secret could contain special characters that are not user or bash friendly.  Especially in bash scripts, special characters often have meaning. Removing the following characters: `"`, `\`.

Ref: https://cloud-native.slack.com/archives/C05TN9WFN5S/p1717410133645919