### PR TITLE
remove html escape

### DIFF
--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -179,13 +179,10 @@ func renderTemplate(templatePath string, outWriter io.Writer, data []any) error 
 func printOutput(templatePath string, outWriter io.Writer, data []any, format string) error {
 	switch format {
 	case "json":
-		b, err := json.MarshalIndent(data, "", "  ")
-		if err != nil {
-			return err
-		}
-		b = append(b, []byte("\n")...)
-		_, err = outWriter.Write(b)
-		return err
+		enc := json.NewEncoder(outWriter)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		return enc.Encode(data)
 	case "yaml":
 		b, err := yaml.Marshal(data)
 		if err != nil {


### PR DESCRIPTION
As mentioned by @cmoulliard in #283 , the get secret json output escapes certain special characters. This behaviour is not desirable for our purposes.


https://pkg.go.dev/encoding/json#Encoder.SetEscapeHTML