### PR TITLE
fix go revision for argocd-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.3
 
 require (
 	code.gitea.io/sdk/gitea v0.16.0
-	github.com/cnoe-io/argocd-api v0.0.0-20240529230753-bb9d05f9e1d8
+	github.com/cnoe-io/argocd-api v0.0.0-20240530220153-91a5bf06f21d
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cnoe-io/argocd-api v0.0.0-20240529230753-bb9d05f9e1d8 h1:BYnQciuk2mQl3rE2B+P3u4Od7PK7PMUxUfRlz3cXIeA=
-github.com/cnoe-io/argocd-api v0.0.0-20240529230753-bb9d05f9e1d8/go.mod h1:vc5mQ/ctD9dFYbWrYHyOclTdbbYU5p+QoFgJBG21RQQ=
+github.com/cnoe-io/argocd-api v0.0.0-20240530220153-91a5bf06f21d h1:rJ1qqRUpEnF8ch+0izhYKnCKdatykDJCmpW0eff7Sxg=
+github.com/cnoe-io/argocd-api v0.0.0-20240530220153-91a5bf06f21d/go.mod h1:vc5mQ/ctD9dFYbWrYHyOclTdbbYU5p+QoFgJBG21RQQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=


### PR DESCRIPTION
looks like it is pulling a non-existing version for the repo.