### PR TITLE
ensure only yaml files are processed

### DIFF
--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -454,7 +454,7 @@ func (r *LocalbuildReconciler) reconcileCustomPkgDir(ctx context.Context, resour
 
 	for i := range files {
 		file := files[i]
-		if !file.Type().IsRegular() {
+		if !file.Type().IsRegular() || !util.IsYamlFile(file.Name()) {
 			continue
 		}
 

--- a/pkg/util/git_repository.go
+++ b/pkg/util/git_repository.go
@@ -85,7 +85,7 @@ func GetWorktreeYamlFiles(parent string, wt billy.Filesystem, recurse bool) ([]s
 			}
 			paths = append(paths, rPaths...)
 		}
-		if ent.Mode().IsRegular() && (strings.HasSuffix(ent.Name(), "yaml") || strings.HasSuffix(ent.Name(), "yml")) {
+		if ent.Mode().IsRegular() && IsYamlFile(ent.Name()) {
 			paths = append(paths, fmt.Sprintf("%s/%s", parent, ent.Name()))
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"math/big"
 	mathrand "math/rand"
+	"path/filepath"
 	"strings"
 
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
@@ -122,4 +123,9 @@ func getRandElement(input string) (string, error) {
 	}
 
 	return string(input[position.Int64()]), nil
+}
+
+func IsYamlFile(input string) bool {
+	extension := filepath.Ext(input)
+	return extension == ".yaml" || extension == ".yml"
 }


### PR DESCRIPTION
We should be looking at yaml files only when processing custom packages. 