### PR TITLE
add email addresses to users in keycloak

### DIFF
--- a/examples/ref-implementation/keycloak/manifests/keycloak-config.yaml
+++ b/examples/ref-implementation/keycloak/manifests/keycloak-config.yaml
@@ -100,7 +100,7 @@ data:
   user-user1.json: |
     {
         "username": "user1",
-        "email": "",
+        "email": "user1@noreply.com",
         "firstName": "user",
         "lastName": "one",
         "requiredActions": [],
@@ -113,7 +113,7 @@ data:
   user-user2.json: |
     {
         "username": "user2",
-        "email": "",
+        "email": "user2@noreply.com",
         "firstName": "user",
         "lastName": "two",
         "requiredActions": [],


### PR DESCRIPTION
In preparation for adding the observability stack, Grafana requires an email address for SSO users. 