### PR TITLE
Add `get packages` sub-command

### DIFF
--- a/pkg/cmd/get/packages.go
+++ b/pkg/cmd/get/packages.go
@@ -1,0 +1,34 @@
+package get
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	packageTemplatePath = "templates/package.tmpl"
+)
+
+var PackagesCmd = &cobra.Command{
+	Use:   "packages",
+	Short: "retrieve package info from the cluster",
+	Long:  ``,
+	RunE:  getPackagesE,
+}
+
+type PackageTemplateData struct {
+	Name        string                  `json:"name"`
+	Namespace   string                  `json:"namespace"`
+	Category    string                  `json:"category"`
+	PackageType string                  `json:"packageType"`
+	Spec        PackageSpecTemplateData `json:"spec"`
+}
+
+type PackageSpecTemplateData struct {
+	Description string            `json:"description"`
+	URL         string            `json:"url"`
+	Credentials map[string]string `json:"credentials"`
+}
+
+func getPackagesE(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/pkg/cmd/get/packages_test.go
+++ b/pkg/cmd/get/packages_test.go
@@ -1,0 +1,1 @@
+package get

--- a/pkg/cmd/get/root.go
+++ b/pkg/cmd/get/root.go
@@ -1,10 +1,14 @@
 package get
 
 import (
+	"embed"
 	"fmt"
 
 	"github.com/spf13/cobra"
 )
+
+//go:embed templates
+var templates embed.FS
 
 var GetCmd = &cobra.Command{
 	Use:   "get",

--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"context"
-	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,9 +30,6 @@ const (
 	giteaAdminSecretName         = "gitea-credential"
 )
 
-//go:embed templates
-var templates embed.FS
-
 var SecretsCmd = &cobra.Command{
 	Use:   "secrets",
 	Short: "retrieve secrets from the cluster",
@@ -47,7 +43,7 @@ var corePkgSecrets = map[string][]string{
 	"gitea":  []string{giteaAdminSecretName},
 }
 
-type TemplateData struct {
+type SecretTemplateData struct {
 	Name      string            `json:"name"`
 	Namespace string            `json:"namespace"`
 	Data      map[string]string `json:"data"`
@@ -197,8 +193,8 @@ func printOutput(templatePath string, outWriter io.Writer, data []any, format st
 	}
 }
 
-func secretToTemplateData(s v1.Secret) TemplateData {
-	data := TemplateData{
+func secretToTemplateData(s v1.Secret) SecretTemplateData {
+	data := SecretTemplateData{
 		Name:      s.Name,
 		Namespace: s.Namespace,
 		Data:      make(map[string]string),

--- a/pkg/cmd/get/secrets_test.go
+++ b/pkg/cmd/get/secrets_test.go
@@ -144,7 +144,7 @@ func TestOutput(t *testing.T) {
 	ctx := context.Background()
 	r, _ := labels.NewRequirement(v1alpha1.CLISecretLabelKey, selection.Equals, []string{v1alpha1.CLISecretLabelValue})
 
-	corePkgData := map[string]TemplateData{
+	corePkgData := map[string]SecretTemplateData{
 		argoCDInitialAdminSecretName: {
 			Name:      argoCDInitialAdminSecretName,
 			Namespace: "argocd",
@@ -163,7 +163,7 @@ func TestOutput(t *testing.T) {
 		},
 	}
 
-	packageData := map[string]TemplateData{
+	packageData := map[string]SecretTemplateData{
 		"name1": {
 			Name:      "name1",
 			Namespace: "ns1",
@@ -217,7 +217,7 @@ func TestOutput(t *testing.T) {
 	assert.Nil(t, err)
 
 	// verify received json data
-	var received []TemplateData
+	var received []SecretTemplateData
 	err = json.Unmarshal(buffer.Bytes(), &received)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(received))
@@ -243,7 +243,7 @@ func TestOutput(t *testing.T) {
 	assert.Equal(t, 0, len(packageData))
 }
 
-func templateDataToSecret(data TemplateData) v1.Secret {
+func templateDataToSecret(data SecretTemplateData) v1.Secret {
 	d := make(map[string][]byte)
 	for k := range data.Data {
 		d[k] = []byte(data.Data[k])

--- a/pkg/cmd/get/templates/package.tmpl
+++ b/pkg/cmd/get/templates/package.tmpl
@@ -1,0 +1,12 @@
+---
+name: {{ .Name }}
+namespace: {{ .Namespace }}
+category: {{ .Category }}
+package-type: {{ .PackageType }}
+spec:
+  description: {{ .Description }}
+  url: {{ .URL }}
+  credentials:
+{{- range $key, $value := .Credentials }}
+    {{ $key }}: {{ $value }}
+{{- end }}

--- a/pkg/cmd/get/templates/secrets.tmpl
+++ b/pkg/cmd/get/templates/secrets.tmpl
@@ -1,7 +1,7 @@
----------------------------
-Name: {{ .Name }}
-Namespace: {{ .Namespace }}
-Data:
+---
+name: {{ .Name }}
+namespace: {{ .Namespace }}
+data:
 {{- range $key, $value := .Data }}
-  {{ $key }} : {{ $value }}
+  {{ $key }}: {{ $value }}
 {{- end }}


### PR DESCRIPTION
* Unify `get` command output formatting
  * yaml-consistent three-dash start of file enables output yaml parsing
  * lowercase keys
  * key: value spacing for secrets.data and packages.spec.credentials

+ Add packages output template

* Common go:embed moved to root.go file