### PR TITLE
codespell: ignore generated manifests

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -23,5 +23,5 @@ jobs:
         with:
           check_filenames: true
           # When using this Action in other repos, the --skip option below can be removed
-          skip: "*.excalidraw,*.git,*.png,*.jpg,*.svg,go.mod,go.sum"
+          skip: "*.excalidraw,*.git,*.png,*.jpg,*.svg,go.mod,go.sum,./pkg/controllers/localbuild/resources"
         continue-on-error: true # The PR checks will not fail, but the possible spelling issues will still be reported for review and correction

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
-        args: ["--skip=*.excalidraw,*.git,*.png,*.jpg,*.svg,go.sum,go.mod"]
+        args: ["--skip=*.excalidraw,*.git,*.png,*.jpg,*.svg,go.sum,go.mod,./pkg/controllers/localbuild/resources"]


### PR DESCRIPTION
We shouldn't care about spelling on generated resources or resources managed by upstream.