### PR TITLE
Adding nightly builds to idpbuilder

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,17 +47,16 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const PREVIOUS_NIGHTLY_TAG = process.env
             const latestRelease = await github.rest.repos.getReleaseByTag({ 
-              owner: ${{ github.repository_owner }}, 
-              repo: ${{ github.event.repository.name }}, 
-              tag: "v0.6.0-nightly.20240623"
+              owner: "${{ github.repository_owner }}", 
+              repo: "${{ github.event.repository.name }}", 
+              tag: "${{ env.PREVIOUS_NIGHTLY_TAG }}"
             });
             console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({
-                owner: ${{ github.repository_owner }},
-                repo: ${{ github.event.repository.name }},
+                owner: "${{ github.repository_owner }}",
+                repo: "${{ github.event.repository.name }}",
                 release_id: latestRelease.data.id,
               });
               console.log(`Release id ${latestRelease.data.id} has been deleted.`);

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -38,10 +38,7 @@ jobs:
           TAG="${MAJOR_VERSION}.${MINOR_VERSION}.0-nightly.$(date +'%Y%m%d')"
           git tag -a $TAG -m "$TAG: nightly build"
           git push origin $TAG
-      - name: Set PREVIOUS_TAG in actual release
-        if: ${{ !contains(github.ref, '-nightly') }}
-        # find previous tag by filtering out nightly tags and choosing the
-        # second to last tag (last one is the current release)
+      - name: Find previous nightly
         run: |
           prev_tag=$(git tag | grep "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
           echo "PREVIOUS_NIGHTLY_TAG=$prev_tag" >> $GITHUB_ENV
@@ -51,13 +48,14 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const latestRelease = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            console.log(latestRelease)
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({
-              ${{ github.repository_owner }},
-              ${{ github.event.repository.name }},
-              release_id: latestRelease.data.id,
-            });
-            console.log(`Release id ${latestRelease.data.id} has been deleted.`);
+                ${{ github.repository_owner }},
+                ${{ github.event.repository.name }},
+                release_id: latestRelease.data.id,
+              });
+              console.log(`Release id ${latestRelease.data.id} has been deleted.`);
             } else {
               console.log("No latest release found or failed to retrieve it.");
             }

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,5 +50,14 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const { data: { id } } = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            await github.rest.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, release_id: id })
+            const latestRelease = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            if (latestRelease && latestRelease.data && latestRelease.data.id) {
+              await github.rest.repos.deleteRelease({
+              ${{ github.repository_owner }},
+              ${{ github.event.repository.name }},
+              release_id: latestRelease.data.id,
+            });
+            console.log(`Release id ${latestRelease.data.id} has been deleted.`);
+            } else {
+              console.log("No latest release found or failed to retrieve it.");
+            }

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,4 +51,4 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { data: { id } } = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            await github.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, release_id: id })
+            await github.rest.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,5 +51,5 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo
-            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ['PREVIOUS_TAG'] })
+            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ${{ env.PREVIOUS_TAG }} })
             await github.repos.deleteRelease({ owner, repo, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,10 +46,9 @@ jobs:
           prev_tag=$(git tag | grep "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
           echo "PREVIOUS_NIGHTLY_TAG=$prev_tag" >> $GITHUB_ENV
       - name: 'Clean up nightly releases'
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const { owner, repo } = context.repo
-            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            await github.repos.deleteRelease({ owner, repo, release_id: id })
+            const { data: { id } } = await github.rest.repos.getReleaseByTag({ context.repo.owner, context.repo.repo, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            await github.repos.deleteRelease({ context.repo.owner, context.repo.repo, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,55 @@
+name: nightly
+on:
+  # This can be used to automatically publish nightlies at UTC nighttime
+  schedule:
+    - cron: '0 7 * * *' # run at 7 AM UTC
+  # This can be used to allow manually triggering nightlies from the web interface
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CNOE_GH_WORKFLOW_TOKEN_APP_ID }}
+          private-key: ${{ secrets.CNOE_GH_WORKFLOW_TOKEN_PRIVATE_KEY }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+      -
+        name: 'Push new tag'
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+          # A previous release was created using a lightweight tag
+          # git describe by default includes only annotated tags
+          # git describe --tags includes lightweight tags as well
+          DESCRIBE=`git tag -l --sort=-v:refname | grep -v nightly | head -n 1`
+          MAJOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[1]}'`
+          MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
+          MINOR_VERSION="$((${MINOR_VERSION} + 1))"
+          TAG="${MAJOR_VERSION}.${MINOR_VERSION}.0-nightly.$(date +'%Y%m%d')"
+          git tag -a $TAG -m "$TAG: nightly build"
+          git push origin $TAG
+      - name: Set PREVIOUS_TAG in actual release
+        if: ${{ !contains(github.ref, '-nightly') }}
+        # find previous tag by filtering out nightly tags and choosing the
+        # second to last tag (last one is the current release)
+        run: |
+          prev_tag=$(git tag | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
+          echo "PREVIOUS_TAG=$prev_tag" >> $GITHUB_ENV
+      - name: 'Clean up nightly releases'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo
+            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ['PREVIOUS_TAG'] })
+            await github.repos.deleteRelease({ owner, repo, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,15 +44,22 @@ jobs:
           echo "PREVIOUS_NIGHTLY_TAG=$prev_tag" >> $GITHUB_ENV
       - name: 'Clean up nightly releases'
         uses: actions/github-script@v7
+        env:
+          PREVIOUS_NIGHTLY_TAG: ${{ env.PREVIOUS_NIGHTLY_TAG }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const latestRelease = await github.rest.repos.getReleaseByTag({ owner: ${{ github.repository_owner }}, repo: ${{ github.event.repository.name }}, tag: ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            const PREVIOUS_NIGHTLY_TAG = process.env
+            const latestRelease = await github.rest.repos.getReleaseByTag({ 
+              owner: ${{ github.repository_owner }}, 
+              repo: ${{ github.event.repository.name }}, 
+              tag: ${{ PREVIOUS_NIGHTLY_TAG }} 
+            });
             console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({
-                ${{ github.repository_owner }},
-                ${{ github.event.repository.name }},
+                owner: ${{ github.repository_owner }},
+                repo: ${{ github.event.repository.name }},
                 release_id: latestRelease.data.id,
               });
               console.log(`Release id ${latestRelease.data.id} has been deleted.`);

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const latestRelease = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            const latestRelease = await github.rest.repos.getRelease({ owner: ${{ github.repository_owner }}, repo: ${{ github.event.repository.name }}, title: ${{ env.PREVIOUS_NIGHTLY_TAG }} })
             console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,5 +50,5 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const { data: { id } } = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.repository }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            await github.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.repository }}, release_id: id })
+            const { data: { id } } = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            await github.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,5 +50,5 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const { data: { id } } = await github.rest.repos.getReleaseByTag({ context.repo.owner, context.repo.repo, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            await github.repos.deleteRelease({ context.repo.owner, context.repo.repo, release_id: id })
+            const { data: { id } } = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.repository }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            await github.repos.deleteRelease({ ${{ github.repository_owner }}, ${{ github.repository }}, release_id: id })

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,8 +44,6 @@ jobs:
           echo "PREVIOUS_NIGHTLY_TAG=$prev_tag" >> $GITHUB_ENV
       - name: 'Clean up nightly releases'
         uses: actions/github-script@v7
-        env:
-          PREVIOUS_NIGHTLY_TAG: ${{ env.PREVIOUS_NIGHTLY_TAG }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -53,7 +51,7 @@ jobs:
             const latestRelease = await github.rest.repos.getReleaseByTag({ 
               owner: ${{ github.repository_owner }}, 
               repo: ${{ github.event.repository.name }}, 
-              tag: ${{ PREVIOUS_NIGHTLY_TAG }} 
+              tag: "v0.6.0-nightly.20240623"
             });
             console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,7 +48,7 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const latestRelease = await github.rest.repos.getReleaseByTag({ ${{ github.repository_owner }}, ${{ github.event.repository.name }}, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
-            console.log(latestRelease)
+            console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({
                 ${{ github.repository_owner }},

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
-            const latestRelease = await github.rest.repos.getRelease({ owner: ${{ github.repository_owner }}, repo: ${{ github.event.repository.name }}, title: ${{ env.PREVIOUS_NIGHTLY_TAG }} })
+            const latestRelease = await github.rest.repos.getReleaseByTag({ owner: ${{ github.repository_owner }}, repo: ${{ github.event.repository.name }}, tag: ${{ env.PREVIOUS_NIGHTLY_TAG }} })
             console.log(`Release ${latestRelease}`);
             if (latestRelease && latestRelease.data && latestRelease.data.id) {
               await github.rest.repos.deleteRelease({

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,13 +43,13 @@ jobs:
         # find previous tag by filtering out nightly tags and choosing the
         # second to last tag (last one is the current release)
         run: |
-          prev_tag=$(git tag | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
-          echo "PREVIOUS_TAG=$prev_tag" >> $GITHUB_ENV
+          prev_tag=$(git tag | grep "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
+          echo "PREVIOUS_NIGHTLY_TAG=$prev_tag" >> $GITHUB_ENV
       - name: 'Clean up nightly releases'
         uses: actions/github-script@v4
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo
-            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ${{ env.PREVIOUS_TAG }} })
+            const { data: { id } } = await github.repos.getReleaseByTag({ owner, repo, ${{ env.PREVIOUS_NIGHTLY_TAG }} })
             await github.repos.deleteRelease({ owner, repo, release_id: id })

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-nightly.[0-9]+'
 
 permissions:
   contents: write
@@ -18,6 +19,13 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: '1.21.0'
+      - name: Set GORELEASER_PREVIOUS_TAG in actual release
+        if: ${{ !contains(github.ref, '-nightly') }}
+        # find previous tag by filtering out nightly tags and choosing the
+        # second to last tag (last one is the current release)
+        run: |
+          prev_tag=$(git tag | grep -v "nightly" | sort -r --version-sort | head -n 2 | tail -n 1)
+          echo "GORELEASER_PREVIOUS_TAG=$prev_tag" >> $GITHUB_ENV
       # Ensure generation tools run
       - name: build
         run: |
@@ -30,3 +38,4 @@ jobs:
           args: release --clean --timeout 30m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
Addresses #281 

Note: we need to create a repo secret called `GH_NIGHTLY_TOKEN` that has permissions to commit to `idpbuilder` and publish packages. This is a GH limitation: https://github.com/orgs/community/discussions/27028#discussioncomment-3254360

At 12 AM PST, a workflow will run that takes the latest main and pushes it as a new nightly tag. It will then delete the last nightly release. The creation of the new tag will trigger the release workflow to run which will create a new release off the nightly tag. 

I also had to `go fmt` the `root.go` file or the release will fail. 