### PR TITLE
use internally and externally resolvable git url

### DIFF
--- a/pkg/controllers/localbuild/gitea_test.go
+++ b/pkg/controllers/localbuild/gitea_test.go
@@ -1,0 +1,23 @@
+package localbuild
+
+import (
+	"testing"
+
+	"github.com/cnoe-io/idpbuilder/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGiteaInternalBaseUrl(t *testing.T) {
+	c := util.CorePackageTemplateConfig{
+		Protocol:       "http",
+		Port:           "8080",
+		Host:           "cnoe.localtest.me",
+		UsePathRouting: false,
+	}
+
+	s := giteaInternalBaseUrl(c)
+	assert.Equal(t, "http://gitea.cnoe.localtest.me:8080", s)
+	c.UsePathRouting = true
+	s = giteaInternalBaseUrl(c)
+	assert.Equal(t, "http://cnoe.localtest.me:8080/gitea", s)
+}


### PR DESCRIPTION
Currently argocd applications are synced to gitea repositories by using the internal service URLs like `http://my-gitea-http.gitea.svc.cluster.local:3000`. This PR changes the behaviour to use the now internally resolvable URL instead. Users can now use the URL given in the Gitea UI to configure ArgoCD. 