### PR TITLE
ensure latest stable version is downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ The following command can be used as a convenience for installing `idpbuilder`, 
 curl -fsSL https://raw.githubusercontent.com/cnoe-io/idpbuilder/main/hack/install.sh | bash
 ```
 
-or download the latest release with the following commands:
+or download the latest stable release with the following commands:
 
 ```bash
-version=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cnoe-io/idpbuilder/releases/latest)
-version=${version##*/}
-curl -L -o ./idpbuilder.tar.gz "https://github.com/cnoe-io/idpbuilder/releases/download/${version}/idpbuilder-$(uname | awk '{print tolower($0)}')-$(uname -m | sed 's/x86_64/amd64/').tar.gz"
+version=$(curl -s https://api.github.com/repos/cnoe-io/idpbuilder/releases | grep tag_name | grep -o -e '"v[0-9].[0-9].[0-9]"' | head -n1 | sed 's/"//g')
+curl -L --progress-bar -o ./idpbuilder.tar.gz "https://github.com/cnoe-io/idpbuilder/releases/download/${version}/idpbuilder-$(uname | awk '{print tolower($0)}')-$(uname -m | sed 's/x86_64/amd64/').tar.gz"
 tar xzf idpbuilder.tar.gz
 
 ./idpbuilder version

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-version=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cnoe-io/idpbuilder/releases/latest)
-version=${version##*/}
-curl -L -o ./idpbuilder.tar.gz "https://github.com/cnoe-io/idpbuilder/releases/download/${version}/idpbuilder-$(uname | awk '{print tolower($0)}')-$(uname -m | sed 's/x86_64/amd64/').tar.gz"
+set -e -o pipefail
+# get the latest stable release by look for tag name pattern like 'v*.*.*'.  For example, v1.1.1
+# GitHub API returns releases in chronological order so we take the first matching tag name.
+version=$(curl -s https://api.github.com/repos/cnoe-io/idpbuilder/releases | grep tag_name | grep -o -e '"v[0-9].[0-9].[0-9]"' | head -n1 | sed 's/"//g')
+
+echo "Downloading idpbuilder version ${version}"
+curl -L --progress-bar -o ./idpbuilder.tar.gz "https://github.com/cnoe-io/idpbuilder/releases/download/${version}/idpbuilder-$(uname | awk '{print tolower($0)}')-$(uname -m | sed 's/x86_64/amd64/').tar.gz"
 tar xzf idpbuilder.tar.gz
 
-./idpbuilder version
-
+echo "Moving idpbuilder binary to /usr/local/bin"
 sudo mv ./idpbuilder /usr/local/bin/
+idpbuilder version
+echo "Successfully installed idpbuilder"


### PR DESCRIPTION
Right now, the install script and the install instructions downloads the latest nightly release. This is not what we want. We want users to use the latest stable version. 

Currently:

```bash
version=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/cnoe-io/idpbuilder/releases/latest)
version=${version##*/}
echo $version
v0.6.0-nightly.20240705 
```

With this PR:

```bash
version=$(curl -s https://api.github.com/repos/cnoe-io/idpbuilder/releases | grep tag_name | grep -o -e '"v[0-9].[0-9].[0-9]"' | head -n1 | sed 's/"//g')
echo $version
v0.5.0
```
