### PR TITLE
add templating support

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -28,7 +28,7 @@ var (
 
 type Build struct {
 	name                 string
-	cfg                  util.CorePackageTemplateConfig
+	cfg                  util.PackageTemplateConfig
 	kindConfigPath       string
 	kubeConfigPath       string
 	kubeVersion          string
@@ -43,7 +43,7 @@ type Build struct {
 
 type NewBuildOptions struct {
 	Name                 string
-	TemplateData         util.CorePackageTemplateConfig
+	TemplateData         util.PackageTemplateConfig
 	KindConfigPath       string
 	KubeConfigPath       string
 	KubeVersion          string
@@ -115,7 +115,7 @@ func (b *Build) GetKubeClient(kubeConfig *rest.Config) (client.Client, error) {
 
 func (b *Build) ReconcileCRDs(ctx context.Context, kubeClient client.Client) error {
 	// Ensure idpbuilder CRDs
-	if err := controllers.EnsureCRDs(ctx, b.scheme, kubeClient, b.cfg); err != nil {
+	if err := controllers.EnsureCRDs(ctx, b.scheme, kubeClient, b.cfg.Data); err != nil {
 		setupLog.Error(err, "Error creating idpbuilder CRDs")
 		return err
 	}
@@ -184,6 +184,7 @@ func (b *Build) Run(ctx context.Context, recreateCluster bool) error {
 		return err
 	}
 	b.cfg.SelfSignedCert = string(cert)
+	b.cfg.Data["SelfSignedCert"] = string(cert)
 
 	setupLog.V(1).Info("Running controllers")
 	if err := b.RunControllers(ctx, mgr, managerExit, dir); err != nil {

--- a/pkg/build/coredns.go
+++ b/pkg/build/coredns.go
@@ -22,7 +22,7 @@ const (
 //go:embed templates
 var templates embed.FS
 
-func setupCoreDNS(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, templateData util.CorePackageTemplateConfig) error {
+func setupCoreDNS(ctx context.Context, kubeClient client.Client, scheme *runtime.Scheme, templateData util.PackageTemplateConfig) error {
 	checkCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "coredns-conf-default",
@@ -34,7 +34,7 @@ func setupCoreDNS(ctx context.Context, kubeClient client.Client, scheme *runtime
 		return nil
 	}
 
-	objs, err := k8s.BuildCustomizedObjects("", coreDNSTemplatePath, templates, scheme, templateData)
+	objs, err := k8s.BuildCustomizedObjects("", coreDNSTemplatePath, templates, scheme, templateData.Data)
 	if err != nil {
 		return fmt.Errorf("rendering embedded coredns files: %w", err)
 	}

--- a/pkg/build/tls.go
+++ b/pkg/build/tls.go
@@ -173,7 +173,7 @@ func createSelfSignedCertificate(sans []string) ([]byte, []byte, error) {
 	return certOut, privateKeyOut, nil
 }
 
-func setupSelfSignedCertificate(ctx context.Context, logger logr.Logger, kubeclient client.Client, config util.CorePackageTemplateConfig) ([]byte, error) {
+func setupSelfSignedCertificate(ctx context.Context, logger logr.Logger, kubeclient client.Client, config util.PackageTemplateConfig) ([]byte, error) {
 	if err := k8s.EnsureNamespace(ctx, kubeclient, globals.NginxNamespace); err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/helpers/validation.go
+++ b/pkg/cmd/helpers/validation.go
@@ -45,7 +45,7 @@ func ParsePackageStrings(pkgStrings []string) ([]string, []string, error) {
 			continue
 		}
 
-		absPath, err := getAbsPath(loc, true)
+		absPath, err := GetAbsPath(loc, true)
 		if err == nil {
 			local = append(local, absPath)
 			continue
@@ -56,7 +56,7 @@ func ParsePackageStrings(pkgStrings []string) ([]string, []string, error) {
 	return remote, local, nil
 }
 
-func getAbsPath(path string, isDir bool) (string, error) {
+func GetAbsPath(path string, isDir bool) (string, error) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to validate path %s : %w", path, err)
@@ -77,7 +77,7 @@ func getAbsPath(path string, isDir bool) (string, error) {
 func GetAbsFilePaths(paths []string, isDir bool) ([]string, error) {
 	out := make([]string, len(paths))
 	for i := range paths {
-		absPath, err := getAbsPath(paths[i], isDir)
+		absPath, err := GetAbsPath(paths[i], isDir)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/custompackage/controller.go
+++ b/pkg/controllers/custompackage/controller.go
@@ -31,7 +31,7 @@ type Reconciler struct {
 	client.Client
 	Recorder record.EventRecorder
 	Scheme   *runtime.Scheme
-	Config   util.CorePackageTemplateConfig
+	Config   util.PackageTemplateConfig
 	TempDir  string
 	RepoMap  *util.RepoMap
 }

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/app1/cm.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/app1/cm.yaml
@@ -4,3 +4,5 @@ metadata:
   name: config
 data:
   test1: "one"
+  hostName: #{ .Host }#
+  customParam: #{ .custom.value }#

--- a/pkg/controllers/custompackage/test/resources/customPackages/testDir/params.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/testDir/params.yaml
@@ -1,0 +1,2 @@
+custom:
+  value: value1

--- a/pkg/controllers/gitrepository/controller_test.go
+++ b/pkg/controllers/gitrepository/controller_test.go
@@ -63,7 +63,7 @@ type testCase struct {
 	expect      expect
 }
 
-func (t testCase) giteaProvider(ctx context.Context, repo *v1alpha1.GitRepository, kubeClient client.Client, scheme *runtime.Scheme, tmplConfig util.CorePackageTemplateConfig) (gitProvider, error) {
+func (t testCase) giteaProvider(ctx context.Context, repo *v1alpha1.GitRepository, kubeClient client.Client, scheme *runtime.Scheme, tmplConfig util.PackageTemplateConfig) (gitProvider, error) {
 	return &giteaProvider{
 		Client:      kubeClient,
 		Scheme:      scheme,

--- a/pkg/controllers/gitrepository/github.go
+++ b/pkg/controllers/gitrepository/github.go
@@ -39,7 +39,7 @@ type gitHubProvider struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	gitHubClient gitHubClient
-	config       util.CorePackageTemplateConfig
+	config       util.PackageTemplateConfig
 }
 
 func (g *gitHubProvider) createRepository(ctx context.Context, repo *v1alpha1.GitRepository) (repoInfo, error) {

--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -13,7 +13,7 @@ func TestGetRawInstallResources(t *testing.T) {
 		resourcePath: "resources/argo",
 	}
 	resources, err := util.ConvertFSToBytes(e.resourceFS, e.resourcePath,
-		util.CorePackageTemplateConfig{
+		util.PackageTemplateConfig{
 			Protocol:       "",
 			Host:           "",
 			Port:           "",
@@ -39,7 +39,7 @@ func TestGetK8sInstallResources(t *testing.T) {
 		resourceFS:   installArgoFS,
 		resourcePath: "resources/argo",
 	}
-	objs, err := e.installResources(k8s.GetScheme(), util.CorePackageTemplateConfig{
+	objs, err := e.installResources(k8s.GetScheme(), util.PackageTemplateConfig{
 		Protocol:       "",
 		Host:           "",
 		Port:           "",

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -40,7 +40,7 @@ type LocalbuildReconciler struct {
 	CancelFunc     context.CancelFunc
 	ExitOnSync     bool
 	shouldShutdown bool
-	Config         util.CorePackageTemplateConfig
+	Config         util.PackageTemplateConfig
 	TempDir        string
 	RepoMap        *util.RepoMap
 }
@@ -434,7 +434,7 @@ func (r *LocalbuildReconciler) reconcileCustomPkgUrl(ctx context.Context, resour
 
 		rErr := r.reconcileCustomPkg(ctx, resource, b, yamlFile, remote)
 		if rErr != nil {
-			logger.Error(rErr, "reconciling custom pkg", "file", yamlFile, "pkgUrl", pkgUrl)
+			logger.V(1).Info("reconciling custom pkg", "file", yamlFile, "pkgUrl", pkgUrl, "error", rErr)
 		}
 	}
 	return ctrl.Result{}, nil
@@ -463,7 +463,7 @@ func (r *LocalbuildReconciler) reconcileCustomPkgDir(ctx context.Context, resour
 
 		rErr := r.reconcileCustomPkg(ctx, resource, b, filePath, nil)
 		if rErr != nil {
-			logger.Error(rErr, "reconciling custom pkg", "file", filePath, "pkgDir", pkgDir)
+			logger.V(1).Info("reconciling custom pkg", "file", filePath, "pkgDir", pkgDir, "error", rErr)
 		}
 	}
 

--- a/pkg/controllers/localbuild/gitea.go
+++ b/pkg/controllers/localbuild/gitea.go
@@ -123,12 +123,12 @@ func (r *LocalbuildReconciler) ReconcileGitea(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-func giteaBaseUrl(config util.CorePackageTemplateConfig) string {
+func giteaBaseUrl(config util.PackageTemplateConfig) string {
 	return fmt.Sprintf(giteaIngressURL, config.Protocol, config.Port)
 }
 
 // gitea URL reachable within the cluster with proper coredns config. Mainly for argocd
-func giteaInternalBaseUrl(config util.CorePackageTemplateConfig) string {
+func giteaInternalBaseUrl(config util.PackageTemplateConfig) string {
 	if config.UsePathRouting {
 		return fmt.Sprintf(giteaSvcURL, config.Protocol, "", config.Host, config.Port, "/gitea")
 	}

--- a/pkg/controllers/localbuild/gitea_test.go
+++ b/pkg/controllers/localbuild/gitea_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGiteaInternalBaseUrl(t *testing.T) {
-	c := util.CorePackageTemplateConfig{
+	c := util.PackageTemplateConfig{
 		Protocol:       "http",
 		Port:           "8080",
 		Host:           "cnoe.localtest.me",

--- a/pkg/controllers/localbuild/installer.go
+++ b/pkg/controllers/localbuild/installer.go
@@ -53,11 +53,11 @@ func (e *EmbeddedInstallation) newNamespace(namespace string) *corev1.Namespace 
 	}
 }
 
-func (e *EmbeddedInstallation) Install(ctx context.Context, resource *v1alpha1.Localbuild, cli client.Client, sc *runtime.Scheme, cfg util.CorePackageTemplateConfig) (ctrl.Result, error) {
+func (e *EmbeddedInstallation) Install(ctx context.Context, resource *v1alpha1.Localbuild, cli client.Client, sc *runtime.Scheme, cfg util.PackageTemplateConfig) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	nsClient := client.NewNamespacedClient(cli, e.namespace)
-	installObjs, err := e.installResources(sc, cfg)
+	installObjs, err := e.installResources(sc, cfg.Data)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -18,7 +18,7 @@ func RunControllers(
 	exitCh chan error,
 	ctxCancel context.CancelFunc,
 	exitOnSync bool,
-	cfg util.CorePackageTemplateConfig,
+	cfg util.PackageTemplateConfig,
 	tmpDir string,
 ) error {
 	logger := log.FromContext(ctx)

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -38,7 +38,7 @@ func TestBuildCustomizedManifests(t *testing.T) {
 
 	for key := range cases {
 		c := cases[key]
-		b, err := BuildCustomizedManifests(c.filePath, c.fsPath, testDataFS, GetScheme(), util.CorePackageTemplateConfig{
+		b, err := BuildCustomizedManifests(c.filePath, c.fsPath, testDataFS, GetScheme(), util.PackageTemplateConfig{
 			Protocol:       "http",
 			Host:           "cnoe.localtest.me",
 			IngressHost:    "localhost",

--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	kubeConfigPath    string
 	kindConfigPath    string
 	extraPortsMapping string
-	cfg               util.CorePackageTemplateConfig
+	cfg               util.PackageTemplateConfig
 }
 
 type PortMapping struct {
@@ -100,7 +100,7 @@ func (c *Cluster) getConfig() ([]byte, error) {
 	return retBuff, nil
 }
 
-func NewCluster(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, cfg util.CorePackageTemplateConfig) (*Cluster, error) {
+func NewCluster(name, kubeVersion, kubeConfigPath, kindConfigPath, extraPortsMapping string, cfg util.PackageTemplateConfig) (*Cluster, error) {
 	detectOpt, err := cluster.DetectNodeProvider()
 
 	if err != nil {

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestGetConfig(t *testing.T) {
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "", util.CorePackageTemplateConfig{
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "", util.PackageTemplateConfig{
 		Port: "8443",
 	})
 	if err != nil {
@@ -56,7 +56,7 @@ containerdConfigPatches:
 
 func TestExtraPortMappings(t *testing.T) {
 
-	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222", util.CorePackageTemplateConfig{
+	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222", util.PackageTemplateConfig{
 		Port: "8443",
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func TestRunsOnWrongPort(t *testing.T) {
 	cluster := &Cluster{
 		name:     "test-cluster",
 		provider: mockProvider,
-		cfg: util.CorePackageTemplateConfig{
+		cfg: util.PackageTemplateConfig{
 			Port: "8080",
 		},
 	}

--- a/pkg/util/build_config.go
+++ b/pkg/util/build_config.go
@@ -1,10 +1,36 @@
 package util
 
-type CorePackageTemplateConfig struct {
+type PackageTemplateConfig struct {
 	Protocol       string
 	Host           string
 	IngressHost    string
 	Port           string
 	UsePathRouting bool
 	SelfSignedCert string
+	// Data field contains custom data and all above field name and values. Used for templating.
+	// This is done to avoid end users having to nest every single custom properties when writing templates.
+	Data map[string]any
+}
+
+func NewPackageTemplateConfig(protocol, host, ingressHost, port string, usePathRouting bool, customData map[string]any) PackageTemplateConfig {
+	if customData == nil {
+		customData = make(map[string]any, 6)
+	}
+
+	p := PackageTemplateConfig{
+		Protocol:       protocol,
+		Host:           host,
+		IngressHost:    ingressHost,
+		Port:           port,
+		UsePathRouting: usePathRouting,
+		Data:           customData,
+	}
+
+	p.Data["Protocol"] = p.Protocol
+	p.Data["Host"] = p.Host
+	p.Data["IngressHost"] = p.IngressHost
+	p.Data["Port"] = p.Port
+	p.Data["UsePathRouting"] = p.UsePathRouting
+
+	return p
 }

--- a/pkg/util/git_repository_test.go
+++ b/pkg/util/git_repository_test.go
@@ -63,7 +63,7 @@ func TestCopyTreeToTree(t *testing.T) {
 	src, _, err := CloneRemoteRepoToMemory(context.Background(), spec, 1, false)
 	assert.Nil(t, err)
 
-	err = CopyTreeToTree(src, dst, spec.Path, ".")
+	err = CopyTreeToTree(src, dst, spec.Path, ".", map[string]string{})
 	assert.Nil(t, err)
 	testCopiedFiles(t, src, dst, spec.Path, ".")
 }
@@ -113,4 +113,27 @@ func TestGetWorktreeYamlFiles(t *testing.T) {
 	paths, err = GetWorktreeYamlFiles("./pkg", wt, false)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 0, len(paths))
+}
+
+func TestCopyFile(t *testing.T) {
+	a, err := os.MkdirTemp("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(a)
+	d := map[string]any{
+		"Host":    "abc.abc",
+		"Custom1": "custom1",
+		"Custom2": map[string]string{
+			"abc": "def",
+		},
+	}
+
+	f := filepath.Join(a, "test.yaml")
+	err = Copy("test/template.yaml.tmpl", f, d)
+	assert.NoError(t, err)
+
+	tb, err := os.ReadFile(f)
+	assert.NoError(t, err)
+	eb, err := os.ReadFile("test/expect.yaml")
+	assert.NoError(t, err)
+	assert.YAMLEq(t, string(eb), string(tb))
 }

--- a/pkg/util/test/expect.yaml
+++ b/pkg/util/test/expect.yaml
@@ -1,0 +1,4 @@
+abc:
+  hostName: abc.abc
+  Custom1: custom1
+  Custom2: def

--- a/pkg/util/test/template.yaml.tmpl
+++ b/pkg/util/test/template.yaml.tmpl
@@ -1,0 +1,4 @@
+abc:
+  hostName: #{ .Host }#
+  Custom1: #{ .Custom1 }#
+  Custom2: #{ .Custom2.abc }#


### PR DESCRIPTION
This adds package templating support for idpbuilder. See #295 

1. Introduces a new flag `-F`. This specifies a yaml file with any additional data.
2. Templates are written with `#{` as the delimiter, instead of the usual `{{`. This is to avoid collision with other templates. I am open to changing this. 
3. Values used by core packages are available to custom packages as well. e.g. Host, Port, etc

File: `pkg/controllers/custompackage/test/resources/customPackages/testDir/params.yaml`
```yaml
custom:
  value: value1
```

File: `pkg/controllers/custompackage/test/resources/customPackages/testDir/app1/cm.yaml`
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: config
data:
  test1: "one"
  hostName: #{ .Host }#
  customParam: #{ .custom.value }#
```

Run idpbuilder:
```
/idpbuilder create -p pkg/controllers/custompackage/test/resources/customPackages/testDir \
  -F pkg/controllers/custompackage/test/resources/customPackages/testDir/params.yaml
```

This results in CM applied with the following config:

```yaml
apiVersion: v1
data:
  customParam: value1
  hostName: cnoe.localtest.me
  test1: one
kind: ConfigMap
metadata:
  name: config
  namespace: my-app

```


We probably should add functions from https://github.com/Masterminds/sprig as well because these are very commonly used in K8s templating stuff.

Closes: #295 

