### PR TITLE
support matrix git generator

### DIFF
--- a/pkg/controllers/custompackage/test/resources/customPackages/applicationSet/generator-matrix.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/applicationSet/generator-matrix.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: generator-matrix
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - matrix:
+        generators:
+          - git:
+              repoURL: "cnoe://test1"
+              revision: HEAD
+              files:
+                - path: "**/config.yaml"
+  template:
+    metadata:
+      name: "{{ .name }}"
+      labels:
+        environment: "{{ .environment }}"
+    spec:
+      project: default
+      source:
+        repoURL: "cnoe://test1"
+        targetRevision: HEAD
+        path: "{{ .manifestPath }}/manifests"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: "{{ .namespace }}"
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true


### PR DESCRIPTION
ApplicationSet has a generator called matrix generator: https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Matrix/

This can embed other generators like the git generator. We need to support it for use cases where parameter values are pulled from git. 