### PR TITLE
add support for helm object

### DIFF
--- a/pkg/controllers/custompackage/test/resources/customPackages/helm/app.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/helm/app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app-helm
+  namespace: argocd
+spec:
+  destination:
+    namespace: my-app-helm
+    server: "https://kubernetes.default.svc"
+  source:
+    repoURL: cnoe://test
+    targetRevision: HEAD
+    path: "."
+    helm:
+      valuesObject:
+        repoURLGit: cnoe://test
+        nested:
+          repoURLGit: cnoe://test
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/pkg/controllers/custompackage/test/resources/customPackages/helm/test/Chart.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/helm/test/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: test
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/pkg/controllers/custompackage/test/resources/customPackages/helm/test/templates/cm.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/helm/test/templates/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  test1: "one"

--- a/pkg/controllers/custompackage/test/resources/customPackages/helm/test/values.yaml
+++ b/pkg/controllers/custompackage/test/resources/customPackages/helm/test/values.yaml
@@ -1,0 +1,1 @@
+some: value


### PR DESCRIPTION
fixes: #339 

With this PR we now look at the `helmValueObject` field in ArgoCD applications. 

I ended up implementing a general replacement function that could be used for any field in ArgoCD application spec to replace `cnoe://` with derived git URL. This functionality is not enabled in this PR however. I am not sure if this is something we want to support. 

With this PR, Idpbuilder will look at `repoURL` fields and `helmValueObject` fields only. 