### PR TITLE
refresh argocd apps on exit

### DIFF
--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -1,11 +1,41 @@
 package localbuild
 
 import (
+	"context"
 	"testing"
 
+	argov1alpha1 "github.com/cnoe-io/argocd-api/api/argo/application/v1alpha1"
+	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
+	"github.com/stretchr/testify/mock"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type fakeKubeClient struct {
+	mock.Mock
+	client.Client
+}
+
+func (f *fakeKubeClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	args := f.Called(ctx, list, opts)
+	return args.Error(0)
+}
+
+func (f *fakeKubeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	args := f.Called(ctx, obj, patch, opts)
+	return args.Error(0)
+}
+
+type testCase struct {
+	err         error
+	listApps    []argov1alpha1.Application
+	annotations []map[string]string
+}
 
 func TestGetRawInstallResources(t *testing.T) {
 	e := EmbeddedInstallation{
@@ -52,4 +82,85 @@ func TestGetK8sInstallResources(t *testing.T) {
 	if len(objs) != 58 {
 		t.Fatalf("Expected 58 Argo Install Resources, got: %d", len(objs))
 	}
+}
+
+func TestArgoCDAppAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []testCase{
+		{
+			err: nil,
+			listApps: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       argov1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+						APIVersion: argov1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nil-annotation",
+						Namespace: "argocd",
+					},
+				},
+			},
+			annotations: []map[string]string{
+				{
+					argoCDApplicationAnnotationKeyRefresh: argoCDApplicationAnnotationValueRefreshNormal,
+				},
+			},
+		},
+		{
+			err: nil,
+			listApps: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       argov1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+						APIVersion: argov1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-annotation",
+						Namespace: "argocd",
+						Annotations: map[string]string{
+							"test": "value",
+						},
+					},
+				},
+			},
+			annotations: []map[string]string{
+				{
+					"test":                                "value",
+					argoCDApplicationAnnotationKeyRefresh: argoCDApplicationAnnotationValueRefreshNormal,
+				},
+			},
+		},
+	}
+
+	for i := range cases {
+		c := cases[i]
+		fClient := new(fakeKubeClient)
+		fClient.On("List", ctx, mock.Anything, []client.ListOption{client.InNamespace(argocdNamespace)}).
+			Run(func(args mock.Arguments) {
+				apps := args.Get(1).(*argov1alpha1.ApplicationList)
+				apps.Items = c.listApps
+			}).Return(c.err)
+		for j := range c.annotations {
+			app := c.listApps[j]
+			u := makeUnstructured(app.Name, app.Namespace, app.GroupVersionKind(), c.annotations[j])
+			fClient.On("Patch", ctx, u, client.Apply, []client.PatchOption{client.FieldOwner(v1alpha1.FieldManager)}).Return(nil)
+		}
+		rec := LocalbuildReconciler{
+			Client: fClient,
+		}
+		err := rec.requestArgoCDAppRefresh(ctx)
+		fClient.AssertExpectations(t)
+		assert.NilError(t, err)
+	}
+}
+
+func makeUnstructured(name, namespace string, gvk schema.GroupVersionKind, annotations map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAnnotations(annotations)
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	u.SetGroupVersionKind(gvk)
+	return u
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -65,14 +65,18 @@ func UpdateSyncAnnotation(ctx context.Context, kubeClient client.Client, obj cli
 	}
 	annotations := make(map[string]string, 1)
 	SetLastObservedSyncTimeAnnotationValue(annotations, timeStamp)
+
+	return ApplyAnnotation(ctx, kubeClient, obj, annotations, client.ForceOwnership, client.FieldOwner(v1alpha1.FieldManager))
+}
+
+func ApplyAnnotation(ctx context.Context, kubeClient client.Client, obj client.Object, annotations map[string]string, opts ...client.PatchOption) error {
 	// MUST be unstructured to avoid managing fields we do not care about.
 	u := unstructured.Unstructured{}
 	u.SetAnnotations(annotations)
 	u.SetName(obj.GetName())
 	u.SetNamespace(obj.GetNamespace())
 	u.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
-
-	return kubeClient.Patch(ctx, &u, client.Apply, client.ForceOwnership, client.FieldOwner(v1alpha1.FieldManager))
+	return kubeClient.Patch(ctx, &u, client.Apply, opts...)
 }
 
 func GeneratePassword() (string, error) {


### PR DESCRIPTION
fixes: #134 
related to: #297 

With this, idpbuilder requests ArgoCD to refresh application source when existing. 