### PR TITLE
use go template for gitea registry

### DIFF
--- a/pkg/kind/cluster.go
+++ b/pkg/kind/cluster.go
@@ -46,10 +46,9 @@ type IProvider interface {
 }
 
 type TemplateConfig struct {
+	util.CorePackageTemplateConfig
 	KubernetesVersion string
 	ExtraPortsMapping []PortMapping
-	IngressProtocol   string
-	Port              string
 }
 
 //go:embed resources/*
@@ -89,10 +88,9 @@ func (c *Cluster) getConfig() ([]byte, error) {
 
 	var retBuff []byte
 	if retBuff, err = util.ApplyTemplate(rawConfigTempl, TemplateConfig{
-		KubernetesVersion: c.kubeVersion,
-		ExtraPortsMapping: portMappingPairs,
-		IngressProtocol:   c.cfg.Protocol,
-		Port:              c.cfg.Port,
+		CorePackageTemplateConfig: c.cfg,
+		KubernetesVersion:         c.kubeVersion,
+		ExtraPortsMapping:         portMappingPairs,
 	}); err != nil {
 		return []byte{}, err
 	}

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestGetConfig(t *testing.T) {
 	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "", util.CorePackageTemplateConfig{
+		Host: "cnoe.localtest.me",
 		Port: "8443",
 	})
 	if err != nil {
@@ -57,6 +58,7 @@ containerdConfigPatches:
 func TestExtraPortMappings(t *testing.T) {
 
 	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222", util.CorePackageTemplateConfig{
+		Host: "cnoe.localtest.me",
 		Port: "8443",
 	})
 	if err != nil {

--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -21,7 +21,7 @@ nodes:
   {{ end }}
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ .Host }}:{{ .Port }}"]
-    endpoint = ["https://gitea.cnoe.localtest.me"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .Host }}".tls]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.{{ .Host }}:{{ .Port }}"]
+    endpoint = ["https://gitea.{{ .Host }}"]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."gitea.{{ .Host }}".tls]
     insecure_skip_verify = true

--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -11,7 +11,7 @@ nodes:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
   extraPortMappings:
-  - containerPort: {{ if (eq .IngressProtocol "http")  -}} 80 {{- else -}} 443 {{- end }}
+  - containerPort: {{ if (eq .Protocol "http")  -}} 80 {{- else -}} 443 {{- end }}
     hostPort: {{ .Port }}
     protocol: TCP
   {{ range .ExtraPortsMapping -}}
@@ -21,7 +21,7 @@ nodes:
   {{ end }}
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.cnoe.localtest.me:8443"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ .Host }}:{{ .Port }}"]
     endpoint = ["https://gitea.cnoe.localtest.me"]
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."gitea.cnoe.localtest.me".tls]
+  [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .Host }}".tls]
     insecure_skip_verify = true


### PR DESCRIPTION
fixes: #315

```
$ docker login gitea.127.0.0.1.nip.io:8443
Username: giteaadmin
Password:
WARNING! Your password will be stored unencrypted in /home/ubuntu/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded

$ docker tag docker.io/library/ubuntu:24.04 gitea.127.0.0.1.nip.io:8443/giteaadmin/ubuntu:24.04

$ docker push gitea.127.0.0.1.nip.io:8443/giteaadmin/ubuntu:24.04
The push refers to repository [gitea.127.0.0.1.nip.io:8443/giteaadmin/ubuntu]
a30a5965a4f7: Pushed
24.04: digest: sha256:19bc204df71f4086020b609089ebf49b332c2e373ec31e3512644b8ad9615001 size: 529
```