### PR TITLE
use self-signed cert for argocd server

### DIFF
--- a/globals/project.go
+++ b/globals/project.go
@@ -5,7 +5,8 @@ import "fmt"
 const (
 	ProjectName string = "idpbuilder"
 
-	NginxNamespace string = "ingress-nginx"
+	NginxNamespace  string = "ingress-nginx"
+	ArgoCDNamespace string = "argocd"
 
 	SelfSignedCertSecretName = "idpbuilder-cert"
 	SelfSignedCertCMName     = "idpbuilder-cert"

--- a/pkg/controllers/localbuild/argo.go
+++ b/pkg/controllers/localbuild/argo.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
+	"github.com/cnoe-io/idpbuilder/globals"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,10 +14,6 @@ import (
 
 //go:embed resources/argo/*
 var installArgoFS embed.FS
-
-const (
-	argocdNamespace string = "argocd"
-)
 
 func RawArgocdInstallResources(templateData any, config v1alpha1.PackageCustomization, scheme *runtime.Scheme) ([][]byte, error) {
 	return k8s.BuildCustomizedManifests(config.FilePath, "resources/argo", installArgoFS, scheme, templateData)
@@ -27,7 +24,7 @@ func (r *LocalbuildReconciler) ReconcileArgo(ctx context.Context, req ctrl.Reque
 		name:         "Argo CD",
 		resourcePath: "resources/argo",
 		resourceFS:   installArgoFS,
-		namespace:    argocdNamespace,
+		namespace:    globals.ArgoCDNamespace,
 		monitoredResources: map[string]schema.GroupVersionKind{
 			"argocd-server": {
 				Group:   "apps",

--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -6,6 +6,7 @@ import (
 
 	argov1alpha1 "github.com/cnoe-io/argocd-api/api/argo/application/v1alpha1"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
+	"github.com/cnoe-io/idpbuilder/globals"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -137,7 +138,7 @@ func TestArgoCDAppAnnotation(t *testing.T) {
 	for i := range cases {
 		c := cases[i]
 		fClient := new(fakeKubeClient)
-		fClient.On("List", ctx, mock.Anything, []client.ListOption{client.InNamespace(argocdNamespace)}).
+		fClient.On("List", ctx, mock.Anything, []client.ListOption{client.InNamespace(globals.ArgoCDNamespace)}).
 			Run(func(args mock.Arguments) {
 				apps := args.Get(1).(*argov1alpha1.ApplicationList)
 				apps.Items = c.listApps

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -230,7 +230,7 @@ func (r *LocalbuildReconciler) reconcileEmbeddedApp(ctx context.Context, appName
 	app := &argov1alpha1.Application{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
-			Namespace: argocdNamespace,
+			Namespace: globals.ArgoCDNamespace,
 		},
 	}
 
@@ -542,7 +542,7 @@ func (r *LocalbuildReconciler) reconcileGitRepo(ctx context.Context, resource *v
 
 func (r *LocalbuildReconciler) requestArgoCDAppRefresh(ctx context.Context) error {
 	apps := &argov1alpha1.ApplicationList{}
-	err := r.Client.List(ctx, apps, client.InNamespace(argocdNamespace))
+	err := r.Client.List(ctx, apps, client.InNamespace(globals.ArgoCDNamespace))
 	if err != nil {
 		return fmt.Errorf("listing argocd apps for refresh: %w", err)
 	}
@@ -559,7 +559,7 @@ func (r *LocalbuildReconciler) requestArgoCDAppRefresh(ctx context.Context) erro
 
 func (r *LocalbuildReconciler) requestArgoCDAppSetRefresh(ctx context.Context) error {
 	appsets := &argov1alpha1.ApplicationSetList{}
-	err := r.Client.List(ctx, appsets, client.InNamespace(argocdNamespace))
+	err := r.Client.List(ctx, appsets, client.InNamespace(globals.ArgoCDNamespace))
 	if err != nil {
 		return fmt.Errorf("listing argocd apps for refresh: %w", err)
 	}


### PR DESCRIPTION
Currently ArgoCD does not use our cert. This PR changes that. This allows services that want to communicate with ArgoCD to do so without disabling TLS verification all together (still need to import the cert).

```
$ openssl s_client -showcerts -servername argocd.cnoe.localtest.me -connect argocd.cnoe.localtest.me:8443 </dev/null | openssl x509 -text | grep 'Subject Alternative Name' -A 1

            X509v3 Subject Alternative Name:
                DNS:cnoe.localtest.me, DNS:*.cnoe.localtest.me
```

