### PR TITLE
skip refresh if owned by app set

### DIFF
--- a/pkg/controllers/localbuild/argo_test.go
+++ b/pkg/controllers/localbuild/argo_test.go
@@ -133,6 +133,55 @@ func TestArgoCDAppAnnotation(t *testing.T) {
 				},
 			},
 		},
+		{
+			err: nil,
+			listApps: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       argov1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+						APIVersion: argov1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "owned-by-appset",
+						Namespace: "argocd",
+						Annotations: map[string]string{
+							"test": "value",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "ApplicationSet",
+							},
+						},
+					},
+				},
+			},
+			annotations: nil,
+		},
+		{
+			err: nil,
+			listApps: []argov1alpha1.Application{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       argov1alpha1.ApplicationSchemaGroupVersionKind.Kind,
+						APIVersion: argov1alpha1.ApplicationSchemaGroupVersionKind.GroupVersion().String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "owned-by-non-appset",
+						Namespace: "argocd",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Something",
+							},
+						},
+					},
+				},
+			},
+			annotations: []map[string]string{
+				{
+					argoCDApplicationAnnotationKeyRefresh: argoCDApplicationAnnotationValueRefreshNormal,
+				},
+			},
+		},
 	}
 
 	for i := range cases {

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -547,8 +547,15 @@ func (r *LocalbuildReconciler) requestArgoCDAppRefresh(ctx context.Context) erro
 		return fmt.Errorf("listing argocd apps for refresh: %w", err)
 	}
 
+apps:
 	for i := range apps.Items {
 		app := apps.Items[i]
+		for _, o := range app.OwnerReferences {
+			// if this app is owned by an ApplicationSet, we should let the ApplicationSet refresh.
+			if o.Kind == argocdapp.ApplicationSetKind {
+				continue apps
+			}
+		}
 		aErr := r.applyArgoCDAnnotation(ctx, &app, argocdapp.ApplicationKind, argoCDApplicationAnnotationKeyRefresh, argoCDApplicationAnnotationValueRefreshNormal)
 		if aErr != nil {
 			return aErr


### PR DESCRIPTION
On exit, we currently refresh ALL ArgoCD Applications. If applications are owned by application sets, we should not refresh them ourselves. Let ApplicationSets refresh instead.