### PR TITLE
Bump Go version to 1.22

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Run tests
         run: |
           make e2e

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Run tests
         run: |
           make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.21.0'
+          go-version: '1.22'
       - name: Set GORELEASER_PREVIOUS_TAG in actual release
         if: ${{ !contains(github.ref, '-nightly') }}
         # find previous tag by filtering out nightly tags and choosing the

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cnoe-io/idpbuilder
 
-go 1.21.3
+go 1.22
 
 require (
 	code.gitea.io/sdk/gitea v0.16.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cnoe-io/idpbuilder
 
-go 1.22
+go 1.22.0
 
 require (
 	code.gitea.io/sdk/gitea v0.16.0


### PR DESCRIPTION
**Description:**

This pull request addresses Issue #259 by updating the Go version from 1.21 to 1.22. The following changes have been made:

- Updated the Go version in `idpbuilder/go.mod` to 1.22.
- Modified `.github/workflows/e2e.yaml`, `.github/workflows/pr.yaml`, and `.github/workflows/release.yaml` to use Go version 1.22.

These changes are necessary to support the upgrade to Kubernetes 1.30, which requires Go 1.22.
