### PR TITLE
Updated controller tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ HELM_TGZ ?= $(LOCALBIN)/helm.tar.gz
 HELM ?= $(LOCALBIN)/helm
 
 ## Tool Versions
-CONTROLLER_TOOLS_VERSION ?= v0.14.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
## Description
This PR updates the controller-gen version in the `idpbuilder` module to align with the updated Kubernetes version.

## Changes Made
- Updated the `CONTROLLER_TOOLS_VERSION` in the `Makefile` from `v0.14.0` to `v0.15.0`.

## Linked Issue
This PR addresses issue #364 and is related to the Kubernetes update mentioned in issue #260.
