### PR TITLE
run controller gen to update crds

### DIFF
--- a/pkg/controllers/resources/idpbuilder.cnoe.io_custompackages.yaml
+++ b/pkg/controllers/resources/idpbuilder.cnoe.io_custompackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: custompackages.idpbuilder.cnoe.io
 spec:
   group: idpbuilder.cnoe.io

--- a/pkg/controllers/resources/idpbuilder.cnoe.io_gitrepositories.yaml
+++ b/pkg/controllers/resources/idpbuilder.cnoe.io_gitrepositories.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: gitrepositories.idpbuilder.cnoe.io
 spec:
   group: idpbuilder.cnoe.io

--- a/pkg/controllers/resources/idpbuilder.cnoe.io_localbuilds.yaml
+++ b/pkg/controllers/resources/idpbuilder.cnoe.io_localbuilds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: localbuilds.idpbuilder.cnoe.io
 spec:
   group: idpbuilder.cnoe.io


### PR DESCRIPTION
Looks like controller gen was updated but was not run in #369 and nightly release is failing.