### PR TITLE
Added config for gitea to support webhooks trigger

### DIFF
--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -27,6 +27,8 @@ gitea:
     server:
       DOMAIN: '{{- if .UsePathRouting -}} {{ .Host }} {{- else -}} gitea.{{- .Host }} {{- end }}'
       ROOT_URL: '{{- if .UsePathRouting }} {{- .Protocol }}://{{ .Host }}:{{ .Port }}/gitea {{- else }} {{- .Protocol }}://gitea.{{ .Host }}:{{ .Port }} {{- end }}'
+    webhook:
+      ALLOWED_HOST_LIST: '*'
 
 service:
   ssh:

--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -29,6 +29,7 @@ gitea:
       ROOT_URL: '{{- if .UsePathRouting }} {{- .Protocol }}://{{ .Host }}:{{ .Port }}/gitea {{- else }} {{- .Protocol }}://gitea.{{ .Host }}:{{ .Port }} {{- end }}'
     webhook:
       ALLOWED_HOST_LIST: private
+      SKIP_TLS_VERIFY: true
 
 service:
   ssh:

--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -28,7 +28,7 @@ gitea:
       DOMAIN: '{{- if .UsePathRouting -}} {{ .Host }} {{- else -}} gitea.{{- .Host }} {{- end }}'
       ROOT_URL: '{{- if .UsePathRouting }} {{- .Protocol }}://{{ .Host }}:{{ .Port }}/gitea {{- else }} {{- .Protocol }}://gitea.{{ .Host }}:{{ .Port }} {{- end }}'
     webhook:
-      ALLOWED_HOST_LIST: '*'
+      ALLOWED_HOST_LIST: private
 
 service:
   ssh:

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -41,7 +41,7 @@ stringData:
   session: |-
     PROVIDER=memory
     PROVIDER_CONFIG=
-  webhook:
+  webhook: |-
     ALLOWED_HOST_LIST=*
     SKIP_TLS_VERIFY=true
 ---

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -42,7 +42,7 @@ stringData:
     PROVIDER=memory
     PROVIDER_CONFIG=
   webhook: |-
-    ALLOWED_HOST_LIST=*
+    ALLOWED_HOST_LIST=private
     SKIP_TLS_VERIFY=true
 ---
 # Source: gitea/templates/gitea/config.yaml

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -41,6 +41,9 @@ stringData:
   session: |-
     PROVIDER=memory
     PROVIDER_CONFIG=
+  webhook:
+    ALLOWED_HOST_LIST=*
+    SKIP_TLS_VERIFY=true
 ---
 # Source: gitea/templates/gitea/config.yaml
 apiVersion: v1


### PR DESCRIPTION
Gitea webhook event POST call is failing with `webhook can only call allowed HTTP servers (check your webhook.ALLOWED_HOST_LIST setting)`, fixing this issue by adding webhook settings to allow private IPs and Skip TLS Verify.