### PR TITLE
run generate command

### DIFF
--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -417,7 +417,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9b7b5c7586d38c5c0feeb0c69191c8fbdb6bfac258ad125dd26b9a125ed67173
+        checksum/config: 94b0102e29e8bd17652180743c848722b184530813c36ad9fe0705edc22cc716
       labels:
         helm.sh/chart: gitea-10.1.4
         app: gitea


### PR DESCRIPTION
Looks like the generate manifest command was missed in the previous PR. We really need #372 to catch these things in PR builds. This caused the nightly build to fail: https://github.com/cnoe-io/idpbuilder/actions/runs/10898267574