### PR TITLE
generate gitea token

### DIFF
--- a/pkg/controllers/gitrepository/controller.go
+++ b/pkg/controllers/gitrepository/controller.go
@@ -2,7 +2,6 @@ package gitrepository
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -73,15 +72,7 @@ func getFallbackRepositoryURL(repo *v1alpha1.GitRepository, info repoInfo) strin
 func GetGitProvider(ctx context.Context, repo *v1alpha1.GitRepository, kubeClient client.Client, scheme *runtime.Scheme, tmplConfig util.CorePackageTemplateConfig) (gitProvider, error) {
 	switch repo.Spec.Provider.Name {
 	case v1alpha1.GitProviderGitea:
-		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			DialContext: (&net.Dialer{
-				Timeout:   gitTCPTimeout,
-				KeepAlive: 30 * time.Second, // from http.DefaultTransport
-			}).DialContext,
-		}
-		c := &http.Client{Transport: tr, Timeout: gitHTTPTimeout}
-		giteaClient, err := NewGiteaClient(repo.Spec.Provider.GitURL, gitea.SetHTTPClient(c))
+		giteaClient, err := NewGiteaClient(repo.Spec.Provider.GitURL, gitea.SetHTTPClient(util.GetHttpClient()))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,12 +3,16 @@ package util
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"math"
 	"math/big"
 	mathrand "math/rand"
+	"net"
+	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -132,4 +136,15 @@ func getRandElement(input string) (string, error) {
 func IsYamlFile(input string) bool {
 	extension := filepath.Ext(input)
 	return extension == ".yaml" || extension == ".yml"
+}
+
+func GetHttpClient() *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second, // from http.DefaultTransport
+		}).DialContext,
+	}
+	return &http.Client{Transport: tr, Timeout: 30 * time.Second}
 }


### PR DESCRIPTION
This PR makes idpbuilder generate a Gitea admin token. This is useful for use cases such as:

- Cloning Gitea repositories.
- Performing some sort of Gitea related operations. e.g. configure webhook for a repository.

Partially fixes: https://github.com/cnoe-io/idpbuilder/issues/378

Example output: 

```
./idpbuilder get secrets -o json -p gitea
[
  {
    "name": "gitea-credential",
    "namespace": "gitea",
    "data": {
      "password": "E_aaaaa'",
      "token": "aaaaaa",
      "username": "giteaAdmin"
    }
  }
]
```