### PR TITLE
Replace the hard coded DNS name of cnoe.localtest.me with {{.Host}}

### DIFF
--- a/hack/argo-cd/argocd-tls-certs-cm.yaml.tmpl
+++ b/hack/argo-cd/argocd-tls-certs-cm.yaml.tmpl
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: argocd-tls-certs-cm
     app.kubernetes.io/part-of: argocd
 data:
-  'gitea.cnoe.localtest.me': |
+  'gitea.{{.Host}}': |
     {{ .SelfSignedCert | indentNewLines 4 }}
   '{{.Host}}': |
     {{ .SelfSignedCert | indentNewLines 4 }}

--- a/pkg/controllers/localbuild/resources/argo/install.yaml
+++ b/pkg/controllers/localbuild/resources/argo/install.yaml
@@ -21157,7 +21157,7 @@ apiVersion: v1
 data:
   '{{.Host}}': |
     {{ .SelfSignedCert | indentNewLines 4 }}
-  gitea.cnoe.localtest.me: |
+  gitea.{{.Host}}: |
     {{ .SelfSignedCert | indentNewLines 4 }}
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
- Replace the hard coded DNS name of cnoe.localtest.me with `gitea.{{.Host}}` within the configMap used by Argocd to access private git repositories
- Fix #394