### PR TITLE
fail pr action if git is in ditry state

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,4 +16,9 @@ jobs:
       - name: Run tests
         run: |
           make build
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "git is in dirty state";
+            git status --porcelain=2 --branch
+            exit 1
+          fi
           make test


### PR DESCRIPTION
We need the PR build to fail if git is in dirty state to ensure generated files are actually generated, not written manually.

fixes: #398 
