### PR TITLE
Add the missing parameters: answer auto

### DIFF
--- a/pkg/build/templates/coredns/cm-coredns-default.yaml.tmpl
+++ b/pkg/build/templates/coredns/cm-coredns-default.yaml.tmpl
@@ -5,9 +5,12 @@ metadata:
   namespace: kube-system
 data:
   default.conf: |
-    # subdomain names resolves to ingress IP. e.g. gitea.cnoe.localtest.me becomes ingress-nginx-controller.ingress-nginx.svc.cluster.local
+    # Goal: Rewrite rules for in-cluster access to a service: gitea, argocd, etc using the same FQDN as for external access
+
+    # subdomain names e.g. gitea.cnoe.localtest.me resolves to the IP address of the kubernetes ingress service and then will become ingress-nginx-controller.ingress-nginx.svc.cluster.local
     rewrite stop {
-        name regex (.*).{{ .Host }} ingress-nginx-controller.ingress-nginx.svc.cluster.local
+        name regex (.*).{{ .Host }} ingress-nginx-controller.ingress-nginx.svc.cluster.local answer auto
     }
-    # host name resolves to ingress IP
+
+    # host name resolves to the IP address of the kubernetes ingress service
     rewrite name exact {{ .Host }} ingress-nginx-controller.ingress-nginx.svc.cluster.local


### PR DESCRIPTION
- Add the missing parameters `answer auto` to the rewrite rule to let `coreDNS` to generate the answer response
- Why : to avoid a man in the middle DNS attack, to avoid that some CLI running part of a fedora image raise a Host not found while curl, ping, work
- See: #398