### PR TITLE
Workaround for codespaces

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -20,3 +20,4 @@ mkdir $HOME/.kube
 echo "source <(kubectl completion bash)" >> $HOME/.bashrc
 echo "alias k=kubectl" >> $HOME/.bashrc
 echo "complete -F __start_kubectl k" >> $HOME/.bashrc
+docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --subnet fc00:f853:ccd:e793::/64 kind


### PR DESCRIPTION
Docker was updated in Codespaces and it caused an issue with Kind. This is a workaround for it. It just pre-creates the kind network.

For a more permanent fix, we need to update Kind once a new version with the fix is released.

https://github.com/cnoe-io/idpbuilder/issues/412
fixes: https://github.com/cnoe-io/idpbuilder/issues/386