### PR TITLE
use gitea NewClient to catch errors

### DIFF
--- a/pkg/controllers/localbuild/gitea.go
+++ b/pkg/controllers/localbuild/gitea.go
@@ -178,10 +178,12 @@ func (r *LocalbuildReconciler) setGiteaToken(ctx context.Context, secret corev1.
 }
 
 func getGiteaToken(ctx context.Context, baseUrl, username, password string) (string, error) {
-
-	giteaClient := gitea.NewClientWithHTTP(baseUrl, util.GetHttpClient())
-	giteaClient.SetBasicAuth(username, password)
-	giteaClient.SetContext(ctx)
+	giteaClient, err := gitea.NewClient(baseUrl, gitea.SetHTTPClient(util.GetHttpClient()),
+		gitea.SetBasicAuth(username, password), gitea.SetContext(ctx),
+	)
+	if err != nil {
+		return "", fmt.Errorf("creating gitea client: %w", err)
+	}
 	tokens, resp, err := giteaClient.ListAccessTokens(gitea.ListAccessTokensOptions{})
 	if err != nil {
 		return "", fmt.Errorf("listing gitea access tokens. status: %s error : %w", resp.Status, err)

--- a/pkg/controllers/localbuild/gitea_test.go
+++ b/pkg/controllers/localbuild/gitea_test.go
@@ -1,10 +1,15 @@
 package localbuild
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGiteaInternalBaseUrl(t *testing.T) {
@@ -20,4 +25,14 @@ func TestGiteaInternalBaseUrl(t *testing.T) {
 	c.UsePathRouting = true
 	s = giteaInternalBaseUrl(c)
 	assert.Equal(t, "http://cnoe.localtest.me:8080/gitea", s)
+}
+
+func TestGetGiteaToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Second * 35)
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	_, err := getGiteaToken(ctx, ts.URL, "", "")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Related to: #425 


This fixes the nil reference when the gitea client initialization errors out due to a timeout. A timeout can be caused by resource contentions. 