### PR TITLE
ensure kind command outputs are available

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -75,7 +75,7 @@ func NewBuild(opts NewBuildOptions) *Build {
 
 func (b *Build) ReconcileKindCluster(ctx context.Context, recreateCluster bool) error {
 	// Initialize Kind Cluster
-	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.kindConfigPath, b.extraPortsMapping, b.cfg)
+	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.kindConfigPath, b.extraPortsMapping, b.cfg, setupLog)
 	if err != nil {
 		setupLog.Error(err, "Error Creating kind cluster")
 		return err

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -10,6 +10,7 @@ import (
 	runtime "github.com/cnoe-io/idpbuilder/pkg/runtime"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
@@ -82,7 +83,7 @@ containerdConfigPatches:
 			Host:           c.host,
 			Port:           c.port,
 			UsePathRouting: c.usePathRouting,
-		})
+		}, logr.Discard())
 		assert.NoError(t, err)
 
 		cfg, err := cluster.getConfig()
@@ -96,7 +97,7 @@ func TestExtraPortMappings(t *testing.T) {
 	cluster, err := NewCluster("testcase", "v1.26.3", "", "", "22:32222", v1alpha1.BuildCustomizationSpec{
 		Host: "cnoe.localtest.me",
 		Port: "8443",
-	})
+	}, logr.Discard())
 	if err != nil {
 		t.Fatalf("Initializing cluster resource: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestGetConfigCustom(t *testing.T) {
 			Host:     "cnoe.localtest.me",
 			Port:     v.hostPort,
 			Protocol: v.protocol,
-		})
+		}, logr.Discard())
 
 		b, err := c.getConfig()
 		if v.error {

--- a/pkg/kind/kindlogger.go
+++ b/pkg/kind/kindlogger.go
@@ -1,0 +1,68 @@
+package kind
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	kindlog "sigs.k8s.io/kind/pkg/log"
+)
+
+// this is a wrapper of logr.Logger made specifically for kind' logger.
+// this is needed because kind's implementation is internal.
+// https://github.com/kubernetes-sigs/kind/blob/1a8f0473a0785e0975e26739524513e8ee696be3/pkg/log/types.go
+type kindLogger struct {
+	cliLogger *logr.Logger
+}
+
+func (l *kindLogger) Warn(message string) {
+	l.cliLogger.Info(message)
+}
+
+func (l *kindLogger) Warnf(message string, args ...interface{}) {
+	l.cliLogger.Info(fmt.Sprintf(message, args...))
+}
+
+func (l *kindLogger) Error(message string) {
+	l.cliLogger.Error(fmt.Errorf(message), "")
+}
+
+func (l *kindLogger) Errorf(message string, args ...interface{}) {
+	msg := fmt.Sprintf(message, args...)
+	l.cliLogger.Error(fmt.Errorf(msg), "")
+}
+
+func (l *kindLogger) V(level kindlog.Level) kindlog.InfoLogger {
+	return newKindInfoLogger(l.cliLogger, int(level))
+}
+
+// this is a wrapper of logr.Logger made specifically for kind's InfoLogger.
+// https://github.com/kubernetes-sigs/kind/blob/1a8f0473a0785e0975e26739524513e8ee696be3/pkg/log/types.go
+func kindLoggerFromLogr(logrLogger *logr.Logger) *kindLogger {
+	return &kindLogger{
+		cliLogger: logrLogger,
+	}
+}
+
+func newKindInfoLogger(logrLogger *logr.Logger, level int) *kindInfoLogger {
+	return &kindInfoLogger{
+		cliLogger: logrLogger,
+		level:     level + 1, // push log level down. e.g. info log becomes debug+1.
+	}
+}
+
+type kindInfoLogger struct {
+	cliLogger *logr.Logger
+	level     int
+}
+
+func (k *kindInfoLogger) Info(message string) {
+	k.cliLogger.V(k.level).Info(message)
+}
+
+func (k *kindInfoLogger) Infof(message string, args ...interface{}) {
+	k.cliLogger.V(k.level).Info(fmt.Sprintf(message, args...))
+}
+
+func (k *kindInfoLogger) Enabled() bool {
+	return k.cliLogger.Enabled()
+}


### PR DESCRIPTION
Currently, when kind cluster creation fails, the only feedback users get is the status code. It's really not useful for end users and it's very difficult to troubleshoot cluster creation problems.


This PR ensures we log kind errors.

Current:
```
Nov  5 16:14:44 INFO Creating kind cluster logger=setup cluster=my-konflux
Nov  5 16:14:45 ERROR Error starting kind cluster logger=setup err=command "podman run --name my-konflux-control-plane --hostname my-konflux-control-plane --label io.x-k8s.kind.role=control-plane --privileged --tmpfs /tmp --tmpfs /run --volume 3b99d6c3e2675118c358c91abcd4a44c0734c822a60fd0c7b504ad916ef036b7:/var:suid,exec,dev --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --net kind --label io.x-k8s.kind.cluster=my-konflux -e container=podman --cgroupns=private --volume /dev/mapper:/dev/mapper --device /dev/fuse --volume=/run/user/1000/containers/auth.json:/var/lib/kubelet/config.json --publish=0.0.0.0:8443:443/tcp --publish=127.0.0.1:38407:6443/tcp -e KUBECONFIG=/etc/kubernetes/admin.conf docker.io/kindest/
node@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e" failed with error: exit status 125
```

With this PR: 
```
Nov  5 22:03:13 INFO Creating kind cluster logger=setup cluster=localdev
Nov  5 22:03:17 ERROR Error starting kind cluster logger=setup err=command "podman run --name localdev-control-plane --hostname localdev-control-plane --label io.x-k8s.kind.role=control-plane --privileged --tmpfs /tmp --tmpfs /run --volume d669c46978e2d99f883685b44964d50e030f36a227fbd4339269455752f99abc:/var:suid,exec,dev --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --net kind --label io.x-k8s.kind.cluster=localdev -e container=podman --cgroupns=private --device /dev/fuse --publish=0.0.0.0:8443:443/tcp --publish=127.0.0.1:40945:6443/tcp -e KUBECONFIG=/etc/kubernetes/admin.conf docker.io/kindest/node:v1.30.3" failed with error: exit status 127: time="2024-11-05T22:03:15Z" level=warning msg="Error validating CNI config file /home/ubuntu/.config/cni/net.d/kind.conflist: [plugin bridge does not support config version \"1.0.0\" plugin portmap does not support config version \"1.0.0\" plugin firewall does not support config version \"1.0.0\" plugin tuning does not support config version \"1.0.0\"]"
time="2024-11-05T22:03:15Z" level=warning msg="Error validating CNI config file /home/ubuntu/.config/cni/net.d/kind.conflist: [plugin bridge does not support config version \"1.0.0\" plugin portmap does not support config version \"1.0.0\" plugin firewall does not support config version \"1.0.0\" plugin tuning does not support config version \"1.0.0\"]"
time="2024-11-05T22:03:15Z" level=error msg="error loading cached network config: network \"kind\" not found in CNI cache"
time="2024-11-05T22:03:15Z" level=warning msg="falling back to loading from existing plugins on disk"
time="2024-11-05T22:03:15Z" level=warning msg="Error validating CNI config file /home/ubuntu/.config/cni/net.d/kind.conflist: [plugin bridge does not support config version \"1.0.0\" plugin portmap does not support config version \"1.0.0\" plugin firewall does not support config version \"1.0.0\" plugin tuning does not support config version \"1.0.0\"]"
time="2024-11-05T22:03:15Z" level=error msg="Error tearing down partially created network namespace for container 552c1c3662ab3daf02cdec6c152de0552267e140e433c43cf62065f416f1d810: CNI network \"kind\" not found"
Error: error configuring network namespace for container 552c1c3662ab3daf02cdec6c152de0552267e140e433c43cf62065f416f1d810: CNI network "kind" not found
```

In addition, this PR makes kind output available in debug logs:

```
Nov  5 22:03:06 INFO Creating kind cluster logger=setup cluster=localdev
Nov  5 22:03:06 DEBUG+3 Creating cluster "localdev" ...
 logger=setup
Nov  5 22:03:06 DEBUG+3  • Ensuring node image (kindest/node:v1.30.3) 🖼  ...
 logger=setup
Nov  5 22:03:06 DEBUG+2 Image: docker.io/kindest/node:v1.30.3 present locally logger=setup
Nov  5 22:03:07 DEBUG+3  ✓ Ensuring node image (kindest/node:v1.30.3) 🖼
 logger=setup
Nov  5 22:03:07 DEBUG+3  • Preparing nodes 📦   ...
 logger=setup
Nov  5 22:03:09 DEBUG+3  ✗ Preparing nodes 📦
```

fixes: https://github.com/cnoe-io/idpbuilder/issues/432
fixes: #357 