### PR TITLE
Improve the cmd: get clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/api v0.30.5
 	k8s.io/apiextensions-apiserver v0.30.5
 	k8s.io/apimachinery v0.30.5
+	k8s.io/cli-runtime v0.30.5
 	k8s.io/client-go v0.30.5
 	k8s.io/klog/v2 v2.120.1
 	sigs.k8s.io/controller-runtime v0.18.5
@@ -26,6 +27,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
@@ -69,6 +71,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/cnoe-io/argocd-api v0.0.0-20241031202925-3091d64cb3c4/go.mod h1:qItVg
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -141,6 +143,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -284,6 +288,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -357,6 +362,8 @@ k8s.io/apiextensions-apiserver v0.30.5 h1:JfXTIyzXf5+ryncbp7T/uaVjLdvkwtqoNG2vo7
 k8s.io/apiextensions-apiserver v0.30.5/go.mod h1:uVLEME2UPA6UN22i+jTu66B9/0CnsjlHkId+Awo0lvs=
 k8s.io/apimachinery v0.30.5 h1:CQZO19GFgw4zcOjY2H+mJ3k1u1o7zFACTNCB7nu4O18=
 k8s.io/apimachinery v0.30.5/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
+k8s.io/cli-runtime v0.30.5 h1:MWY6efoBVH3h0O6p2DgaQszabV5ZntHZwTHBkiz+PSI=
+k8s.io/cli-runtime v0.30.5/go.mod h1:AKMWLDIJQUA5a7yEh5gmzkhpZqYpuDEVovanugfSnQk=
 k8s.io/client-go v0.30.5 h1:vEDSzfTz0F8TXcWVdXl+aqV7NAV8M3UvC2qnGTTCoKw=
 k8s.io/client-go v0.30.5/go.mod h1:/q5fHHBmhAUesOOFJACpD7VJ4e57rVtTPDOsvXrPpMk=
 k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -1,10 +1,14 @@
 package get
 
 import (
+	"context"
 	"fmt"
-
 	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
+	"github.com/cnoe-io/idpbuilder/pkg/kind"
+	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"os"
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
@@ -16,19 +20,60 @@ var ClustersCmd = &cobra.Command{
 	PreRunE: preClustersE,
 }
 
+var kubeCfgPath string
+
 func preClustersE(cmd *cobra.Command, args []string) error {
 	return helpers.SetLogger()
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	provider := cluster.NewProvider(cluster.ProviderWithDocker())
+	logger := helpers.CmdLogger
+
+	detectOpt, err := util.DetectKindNodeProvider()
+	if err != nil {
+		logger.Error(err, "failed to detect the provider.")
+		os.Exit(1)
+	}
+
+	kubeConfig, err := helpers.GetKubeConfig()
+	if err != nil {
+		logger.Error(err, "failed to create the kube config.")
+		os.Exit(1)
+	}
+
+	cli, err := helpers.GetKubeClient(kubeConfig)
+	if err != nil {
+		logger.Error(err, "failed to create the kube client.")
+		os.Exit(1)
+	}
+
+	provider := cluster.NewProvider(cluster.ProviderWithLogger(kind.KindLoggerFromLogr(&logger)), detectOpt)
 	clusters, err := provider.List()
 	if err != nil {
-		return fmt.Errorf("failed to list clusters: %w", err)
+		logger.Error(err, "failed to list clusters.")
 	}
 
 	for _, c := range clusters {
-		fmt.Println(c)
+		fmt.Printf("Cluster: %s\n", c)
+		var nodeList corev1.NodeList
+		err := cli.List(context.TODO(), &nodeList)
+		if err != nil {
+			logger.Error(err, "failed to list nodes for cluster: %s", c)
+		}
+		for _, node := range nodeList.Items {
+			nodeName := node.Name
+			fmt.Printf("  Node: %s\n", nodeName)
+
+			for _, addr := range node.Status.Addresses {
+				switch addr.Type {
+				case corev1.NodeInternalIP:
+					fmt.Printf("  Internal IP: %s\n", addr.Address)
+				case corev1.NodeExternalIP:
+					fmt.Printf("  External IP: %s\n", addr.Address)
+				}
+			}
+			fmt.Println("----------")
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -362,7 +362,7 @@ func CreateKubeClientForEachIDPCluster(config *api.Config, clusterList []string)
 
 			cl, err := client.New(cfg, client.Options{})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to create client for context %s", contextName)
+				fmt.Errorf("Failed to create client for context %s", contextName)
 				continue
 			}
 

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -10,12 +10,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/kind/pkg/cluster"
+	"slices"
 	"strings"
 )
+
+// ClusterManager holds the clients for the different idpbuilder clusters
+type ClusterManager struct {
+	clients map[string]client.Client // map of cluster name to client
+}
 
 var ClustersCmd = &cobra.Command{
 	Use:     "clusters",
@@ -50,9 +57,16 @@ func list(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	cli, err := helpers.GetKubeClient(kubeConfig)
+	// TODO: Check if we need it or not like also if the new code handle the kubeconfig path passed as parameter
+	_, err = helpers.GetKubeClient(kubeConfig)
 	if err != nil {
 		logger.Error(err, "failed to create the kube client.")
+		os.Exit(1)
+	}
+
+	config, err := helpers.LoadKubeConfig()
+	if err != nil {
+		logger.Error(err, "failed to load the kube config.")
 		os.Exit(1)
 	}
 
@@ -63,13 +77,12 @@ func list(cmd *cobra.Command, args []string) error {
 		logger.Error(err, "failed to list clusters.")
 	}
 
+	// Populate a list of Kube client for each cluster/context matching a idpbuilder cluster
+	manager, _ := CreateKubeClientForEachIDPCluster(config, clusters)
+
+	fmt.Printf("\n")
 	for _, cluster := range clusters {
 		fmt.Printf("Cluster: %s\n", cluster)
-
-		config, err := helpers.LoadKubeConfig()
-		if err != nil {
-			logger.Error(err, "failed to load the kube config.")
-		}
 
 		// Search about the idp cluster within the kubeconfig file and show information
 		c, found := findClusterByName(config, "kind-"+cluster)
@@ -78,53 +91,56 @@ func list(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Printf("URL of the kube API server: %s\n", c.Server)
 			fmt.Printf("TLS Verify: %t\n", c.InsecureSkipTLSVerify)
-		}
 
-		fmt.Println("----------------------------------------")
-	}
+			cli, err := GetClientForCluster(manager, cluster)
+			if err != nil {
+				logger.Error(err, "failed to get the cluster/context for the cluster: %s.", cluster)
+			}
+			// Print the external port that users can access using the ingress nginx proxy
+			service := corev1.Service{}
+			namespacedName := types.NamespacedName{
+				Name:      "ingress-nginx-controller",
+				Namespace: "ingress-nginx",
+			}
+			err = cli.Get(context.TODO(), namespacedName, &service)
+			if err != nil {
+				logger.Error(err, "failed to get the ingress service on the cluster.")
+			}
+			fmt.Printf("External Port: %d", findExternalHTTPSPort(service))
 
-	// Print the external port that users can access using the ingress nginx proxy
-	service := corev1.Service{}
-	namespacedName := types.NamespacedName{
-		Name:      "ingress-nginx-controller",
-		Namespace: "ingress-nginx",
-	}
-	err = cli.Get(context.TODO(), namespacedName, &service)
-	if err != nil {
-		logger.Error(err, "failed to get the ingress service on the cluster.")
-	}
-	fmt.Printf("External Port: %d\n", findExternalHTTPSPort(service))
+			// Let's check what the current node reports
+			var nodeList corev1.NodeList
+			err = cli.List(context.TODO(), &nodeList)
+			if err != nil {
+				logger.Error(err, "failed to list nodes for the current kube cluster.")
+			}
 
-	// Let's check what the current node reports
-	var nodeList corev1.NodeList
-	err = cli.List(context.TODO(), &nodeList)
-	if err != nil {
-		logger.Error(err, "failed to list nodes for the current kube cluster.")
-	}
+			for _, node := range nodeList.Items {
+				nodeName := node.Name
+				fmt.Printf("\n\n")
+				fmt.Printf("Node: %s\n", nodeName)
 
-	for _, node := range nodeList.Items {
-		nodeName := node.Name
-		fmt.Printf("Node: %s\n", nodeName)
+				for _, addr := range node.Status.Addresses {
+					switch addr.Type {
+					case corev1.NodeInternalIP:
+						fmt.Printf("Internal IP: %s\n", addr.Address)
+					case corev1.NodeExternalIP:
+						fmt.Printf("External IP: %s\n", addr.Address)
+					}
+				}
 
-		for _, addr := range node.Status.Addresses {
-			switch addr.Type {
-			case corev1.NodeInternalIP:
-				fmt.Printf("Internal IP: %s\n", addr.Address)
-			case corev1.NodeExternalIP:
-				fmt.Printf("External IP: %s\n", addr.Address)
+				// Show node capacity
+				fmt.Printf("Capacity of the node: \n")
+				printFormattedResourceList(node.Status.Capacity)
+
+				// Show node allocated resources
+				err = printAllocatedResources(context.Background(), cli, node.Name)
+				if err != nil {
+					logger.Error(err, "Failed to get the node's allocated resources.")
+				}
 			}
 		}
-
-		// Show node capacity
-		fmt.Printf("Capacity of the node: \n")
-		printFormattedResourceList(node.Status.Capacity)
-
-		// Show node allocated resources
-		err = printAllocatedResources(context.Background(), cli, node.Name)
-		if err != nil {
-			logger.Error(err, "Failed to get the node's allocated resources.")
-		}
-		fmt.Println("--------------------")
+		fmt.Println("----------------------------------------")
 	}
 
 	return nil
@@ -191,4 +207,43 @@ func findExternalHTTPSPort(service corev1.Service) int32 {
 		}
 	}
 	return targetPort.Port
+}
+
+// GetClientForCluster returns the client for the specified cluster/context name
+func GetClientForCluster(m *ClusterManager, clusterName string) (client.Client, error) {
+	cl, exists := m.clients["kind-"+clusterName]
+	if !exists {
+		return nil, fmt.Errorf("no client found for cluster %q", clusterName)
+	}
+	return cl, nil
+}
+
+func CreateKubeClientForEachIDPCluster(config *api.Config, clusterList []string) (*ClusterManager, error) {
+	// Initialize the ClusterManager with a map of kube Client
+	manager := &ClusterManager{
+		clients: make(map[string]client.Client),
+	}
+
+	for contextName := range config.Contexts {
+		// Check if the kubconfig contains the cluster name
+		// We remove the prefix "kind-" to find the cluster name from the slice
+		if slices.Contains(clusterList, contextName[5:]) {
+			cfg, err := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to build client for context %q: %v\n", contextName, err)
+				continue
+			}
+
+			cl, err := client.New(cfg, client.Options{})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to create client for context %q: %v\n", contextName, err)
+				continue
+			}
+
+			manager.clients[contextName] = cl
+			// fmt.Printf("Client created for context %q\n", contextName)
+		}
+
+	}
+	return manager, nil
 }

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"os"
 	"sigs.k8s.io/kind/pkg/cluster"
 )
@@ -24,6 +25,12 @@ var kubeCfgPath string
 
 func preClustersE(cmd *cobra.Command, args []string) error {
 	return helpers.SetLogger()
+}
+
+// findClusterByName searches for a cluster by name in the kubeconfig
+func findClusterByName(config *api.Config, name string) (*api.Cluster, bool) {
+	cluster, exists := config.Clusters[name]
+	return cluster, exists
 }
 
 func list(cmd *cobra.Command, args []string) error {
@@ -47,19 +54,36 @@ func list(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	// List the idp builder clusters according to the provider: podman or docker
 	provider := cluster.NewProvider(cluster.ProviderWithLogger(kind.KindLoggerFromLogr(&logger)), detectOpt)
 	clusters, err := provider.List()
 	if err != nil {
 		logger.Error(err, "failed to list clusters.")
 	}
 
-	for _, c := range clusters {
-		fmt.Printf("Cluster: %s\n", c)
-		var nodeList corev1.NodeList
-		err := cli.List(context.TODO(), &nodeList)
+	for _, cluster := range clusters {
+		fmt.Printf("Cluster: %s\n", cluster)
+
+		config, err := helpers.LoadKubeConfig()
 		if err != nil {
-			logger.Error(err, "failed to list nodes for cluster: %s", c)
+			logger.Error(err, "failed to load the kube config.")
 		}
+
+		// Search about the idp cluster within the kubeconfig file
+		cluster, found := findClusterByName(config, "kind-"+cluster)
+		if !found {
+			fmt.Printf("Cluster %q not found\n", cluster)
+		} else {
+			fmt.Printf("URL of the kube API server: %s\n", cluster.Server)
+			fmt.Printf("TLS Verify: %t\n", cluster.InsecureSkipTLSVerify)
+		}
+
+		var nodeList corev1.NodeList
+		err = cli.List(context.TODO(), &nodeList)
+		if err != nil {
+			logger.Error(err, "failed to list nodes for cluster: %s", cluster)
+		}
+
 		for _, node := range nodeList.Items {
 			nodeName := node.Name
 			fmt.Printf("  Node: %s\n", nodeName)

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -125,7 +125,7 @@ func populateClusterList() ([]Cluster, error) {
 		c, found := findClusterByName(config, "kind-"+cluster)
 		if !found {
 			//logger.Error(nil, fmt.Sprintf("Cluster not found: %s within kube config file\n", cluster))
-			return nil, err
+			logger.Info(fmt.Sprintf("Cluster not found: %s within kube config file\n", cluster))
 		} else {
 			cli, err := GetClientForCluster(manager, cluster)
 			if err != nil {
@@ -361,14 +361,12 @@ func CreateKubeClientForEachIDPCluster(config *api.Config, clusterList []string)
 		if slices.Contains(clusterList, contextName[5:]) {
 			cfg, err := clientcmd.NewNonInteractiveClientConfig(*config, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 			if err != nil {
-				fmt.Errorf("Failed to build client for context %s.", contextName)
-				continue
+				return nil, fmt.Errorf("Failed to build client for context %s.", contextName)
 			}
 
 			cl, err := client.New(cfg, client.Options{})
 			if err != nil {
-				fmt.Errorf("Failed to create client for context %s", contextName)
-				continue
+				return nil, fmt.Errorf("failed to create client for context %s", contextName)
 			}
 
 			manager.clients[contextName] = cl

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -24,8 +24,6 @@ var ClustersCmd = &cobra.Command{
 	PreRunE: preClustersE,
 }
 
-var kubeCfgPath string
-
 func preClustersE(cmd *cobra.Command, args []string) error {
 	return helpers.SetLogger()
 }
@@ -73,12 +71,12 @@ func list(cmd *cobra.Command, args []string) error {
 		}
 
 		// Search about the idp cluster within the kubeconfig file and show information
-		cluster, found := findClusterByName(config, "kind-"+cluster)
+		c, found := findClusterByName(config, "kind-"+cluster)
 		if !found {
-			fmt.Printf("Cluster %q not found\n", cluster)
+			fmt.Printf("Cluster not found: %s\n", cluster)
 		} else {
-			fmt.Printf("URL of the kube API server: %s\n", cluster.Server)
-			fmt.Printf("TLS Verify: %t\n", cluster.InsecureSkipTLSVerify)
+			fmt.Printf("URL of the kube API server: %s\n", c.Server)
+			fmt.Printf("TLS Verify: %t\n", c.InsecureSkipTLSVerify)
 		}
 		fmt.Println("----------------------------------------")
 	}

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
 	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
+	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/kind"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
@@ -367,7 +368,7 @@ func CreateKubeClientForEachIDPCluster(config *api.Config, clusterList []string)
 				return nil, fmt.Errorf("Failed to build client for context %s.", contextName)
 			}
 
-			cl, err := client.New(cfg, client.Options{})
+			cl, err := client.New(cfg, client.Options{Scheme: k8s.GetScheme()})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create client for context %s", contextName)
 			}

--- a/pkg/cmd/get/root.go
+++ b/pkg/cmd/get/root.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cmd/get/root.go
+++ b/pkg/cmd/get/root.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"fmt"
+	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ func init() {
 	GetCmd.AddCommand(SecretsCmd)
 	GetCmd.PersistentFlags().StringSliceVarP(&packages, "packages", "p", []string{}, "names of packages.")
 	GetCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Output format. json or yaml.")
+	GetCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubeconfig", "", "", "kube config file Path.")
 }
 
 func exportE(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/helpers/k8s.go
+++ b/pkg/cmd/helpers/k8s.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +21,15 @@ func GetKubeConfigPath() string {
 		return filepath.Join(homedir.HomeDir(), ".kube", "config")
 	} else {
 		return KubeConfigPath
+	}
+}
+
+func LoadKubeConfig() (*api.Config, error) {
+	config, err := clientcmd.LoadFromFile(GetKubeConfigPath())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load kubeconfig file: %w", err)
+	} else {
+		return config, nil
 	}
 }
 

--- a/pkg/cmd/helpers/k8s.go
+++ b/pkg/cmd/helpers/k8s.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"path/filepath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	KubeConfigPath string
+	scheme         *runtime.Scheme
+)
+
+func GetKubeConfigPath() string {
+	if KubeConfigPath == "" {
+		return filepath.Join(homedir.HomeDir(), ".kube", "config")
+	} else {
+		return KubeConfigPath
+	}
+}
+
+func GetKubeConfig() (*rest.Config, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", GetKubeConfigPath())
+	if err != nil {
+		return nil, fmt.Errorf("Error building kubeconfig: %w", err)
+	}
+	return kubeConfig, nil
+}
+
+func GetKubeClient(kubeConfig *rest.Config) (client.Client, error) {
+	kubeClient, err := client.New(kubeConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("Error creating kubernetes client: %w", err)
+	}
+	return kubeClient, nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,7 +21,6 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&helpers.LogLevel, "log-level", "l", "info", helpers.LogLevelMsg)
 	rootCmd.PersistentFlags().BoolVar(&helpers.ColoredOutput, "color", false, helpers.ColoredOutputMsg)
-	rootCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubeconfig", "", "", "kube config file Path.")
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
 	rootCmd.AddCommand(delete.DeleteCmd)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&helpers.LogLevel, "log-level", "l", "info", helpers.LogLevelMsg)
 	rootCmd.PersistentFlags().BoolVar(&helpers.ColoredOutput, "color", false, helpers.ColoredOutputMsg)
-	rootCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubePath", "", "", "kube config file Path.")
+	rootCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubeconfig", "", "", "kube config file Path.")
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
 	rootCmd.AddCommand(delete.DeleteCmd)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,6 +21,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&helpers.LogLevel, "log-level", "l", "info", helpers.LogLevelMsg)
 	rootCmd.PersistentFlags().BoolVar(&helpers.ColoredOutput, "color", false, helpers.ColoredOutputMsg)
+	rootCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubePath", "", "", "kube config file Path.")
 	rootCmd.AddCommand(create.CreateCmd)
 	rootCmd.AddCommand(get.GetCmd)
 	rootCmd.AddCommand(delete.DeleteCmd)


### PR DESCRIPTION
- Improve the cmd: get clusters to show the cluster, nodes and their internal IP. 
- Created a help function to access globally to the kube client. 
- Add a new parameter to set the kubeconfig path
```
./idpbuilder -h
Manage reference IDPs

Usage:
  idpbuilder [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  create      (Re)Create an IDP cluster
  delete      Delete an IDP cluster
  get         get information from the cluster
  help        Help about any command
  version     Print idpbuilder version and environment info

Flags:
      --color              Enable colored log messages.
  -h, --help               help for idpbuilder
      --kubePath string    kube config file Path.
```
- Command currently shows:
```
Cluster: my-konflux
URL of the kube API server: https://127.0.0.1:63473
TLS Verify: false
  Node: my-konflux-control-plane
  Internal IP: 10.89.0.2
----------
```
- #445