### PR TITLE
handle command interrupt

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,29 @@
 package main
 
-import "github.com/cnoe-io/idpbuilder/pkg/cmd"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cnoe-io/idpbuilder/pkg/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	interrupted := make(chan os.Signal, 1)
+	defer close(interrupted)
+	signal.Notify(interrupted, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(interrupted)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+
+	go func() {
+		select {
+		case <-interrupted:
+			cancel(fmt.Errorf("command interrupted"))
+		}
+	}()
+
+	cmd.Execute(ctx)
 }

--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -89,8 +89,8 @@ func preCreateE(cmd *cobra.Command, args []string) error {
 
 func create(cmd *cobra.Command, args []string) error {
 
-	ctx, cancel := context.WithCancel(cmd.Context())
-	defer cancel()
+	ctx, ctxCancel := context.WithCancel(cmd.Context())
+	defer ctxCancel()
 
 	kubeConfigPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
 
@@ -152,7 +152,7 @@ func create(cmd *cobra.Command, args []string) error {
 		PackageCustomization: o,
 
 		Scheme:     k8s.GetScheme(),
-		CancelFunc: cancel,
+		CancelFunc: ctxCancel,
 	}
 
 	b := build.NewBuild(opts)

--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/util/homedir"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -54,7 +53,7 @@ type TemplateData struct {
 }
 
 func getSecretsE(cmd *cobra.Command, args []string) error {
-	ctx, ctxCancel := context.WithCancel(ctrl.SetupSignalHandler())
+	ctx, ctxCancel := context.WithCancel(cmd.Context())
 	defer ctxCancel()
 	kubeConfigPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -27,8 +28,8 @@ func init() {
 	rootCmd.AddCommand(version.VersionCmd)
 }
 
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+func Execute(ctx context.Context) {
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/pkg/controllers/run.go
+++ b/pkg/controllers/run.go
@@ -63,15 +63,12 @@ func RunControllers(
 	if err != nil {
 		logger.Error(err, "unable to create custom package controller")
 	}
-
 	// Start our manager in another goroutine
 	logger.V(1).Info("starting manager")
+
 	go func() {
-		if err := mgr.Start(ctx); err != nil {
-			logger.Error(err, "problem running manager")
-			exitCh <- err
-		}
-		exitCh <- nil
+		exitCh <- mgr.Start(ctx)
+		close(exitCh)
 	}()
 
 	return nil


### PR DESCRIPTION
This PR makes idpbuilder handle interrupts correctly. Currently, idpbuilder doesn't handle signals well. For example, if you send ctrl+c while it's executing, it prints out a message saying `Finished Creating IDP Successfully!`. With this PR, it correctly says that the command execution was interrupted. It still prints command usages at the end but we can address that in another PR. 