### PR TITLE
print url for codespaces

### DIFF
--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -160,18 +161,7 @@ func create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	subDomain := "argocd."
-	subPath := ""
-
-	if pathRouting == true {
-		subDomain = ""
-		subPath = "argocd"
-	}
-
-	fmt.Print("\n\n########################### Finished Creating IDP Successfully! ############################\n\n\n")
-	fmt.Printf("Can Access ArgoCD at %s\nUsername: admin\n", fmt.Sprintf("%s://%s%s:%s/%s", protocol, subDomain, host, port, subPath))
-	fmt.Print(`Password can be retrieved by running: idpbuilder get secrets -p argocd`, "\n")
-
+	printSuccessMsg()
 	return nil
 }
 
@@ -223,4 +213,33 @@ func getPackageCustomFile(input string) (v1alpha1.PackageCustomization, error) {
 		Name:     name,
 		FilePath: paths[0],
 	}, nil
+}
+
+func printSuccessMsg() {
+	subDomain := "argocd."
+	subPath := ""
+
+	if pathRouting == true {
+		subDomain = ""
+		subPath = "argocd"
+	}
+
+	var argoURL string
+
+	proxy := behindProxy()
+	if proxy {
+		argoURL = fmt.Sprintf("https://%s/argocd", host)
+	} else {
+		argoURL = fmt.Sprintf("%s://%s%s:%s/%s", protocol, subDomain, host, port, subPath)
+	}
+
+	fmt.Print("\n\n########################### Finished Creating IDP Successfully! ############################\n\n\n")
+	fmt.Printf("Can Access ArgoCD at %s\nUsername: admin\n", argoURL)
+	fmt.Print(`Password can be retrieved by running: idpbuilder get secrets -p argocd`, "\n")
+}
+
+func behindProxy() bool {
+	// check if we are in codespaces: https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+	_, ok := os.LookupEnv("CODESPACES")
+	return ok
 }


### PR DESCRIPTION
This prints the correct URL when idpbuilder is used in Codespaces. We do promote the use of Codespaces to get going quickly so I think it's a good idea to have something small like this to make the experience better. 

If you are using another proxy like Caddy instead, this prints out the URL correctly as well. You just need to set `CODESPACES=true` when running idpbuilder. 

fixes: #269
fixes: #452 