### PR TITLE
prevent printing usages on error

### DIFF
--- a/pkg/cmd/create/root.go
+++ b/pkg/cmd/create/root.go
@@ -55,11 +55,12 @@ var (
 )
 
 var CreateCmd = &cobra.Command{
-	Use:     "create",
-	Short:   "(Re)Create an IDP cluster",
-	Long:    ``,
-	RunE:    create,
-	PreRunE: preCreateE,
+	Use:          "create",
+	Short:        "(Re)Create an IDP cluster",
+	Long:         ``,
+	RunE:         create,
+	PreRunE:      preCreateE,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/pkg/cmd/delete/root.go
+++ b/pkg/cmd/delete/root.go
@@ -16,11 +16,12 @@ var (
 )
 
 var DeleteCmd = &cobra.Command{
-	Use:     "delete",
-	Short:   "Delete an IDP cluster",
-	Long:    ``,
-	RunE:    deleteE,
-	PreRunE: preDeleteE,
+	Use:          "delete",
+	Short:        "Delete an IDP cluster",
+	Long:         ``,
+	RunE:         deleteE,
+	PreRunE:      preDeleteE,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -9,11 +9,12 @@ import (
 )
 
 var ClustersCmd = &cobra.Command{
-	Use:     "clusters",
-	Short:   "Get idp clusters",
-	Long:    ``,
-	RunE:    list,
-	PreRunE: preClustersE,
+	Use:          "clusters",
+	Short:        "Get idp clusters",
+	Long:         ``,
+	RunE:         list,
+	PreRunE:      preClustersE,
+	SilenceUsage: true,
 }
 
 func preClustersE(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -35,10 +35,11 @@ const (
 var templates embed.FS
 
 var SecretsCmd = &cobra.Command{
-	Use:   "secrets",
-	Short: "retrieve secrets from the cluster",
-	Long:  ``,
-	RunE:  getSecretsE,
+	Use:          "secrets",
+	Short:        "retrieve secrets from the cluster",
+	Long:         ``,
+	RunE:         getSecretsE,
+	SilenceUsage: true,
 }
 
 // well known secrets that are part of the core packages


### PR DESCRIPTION
Set `SilenceUsage: true,` for commands to prevent usages from being printed every time an error occurs.

before:

```
idpbuilder get secrets
Error: getting kube config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
Usage:
  idpbuilder get secrets [flags]

Flags:
  -h, --help   help for secrets

Global Flags:
      --color              Enable colored log messages.
  -l, --log-level string   Set the log verbosity. Supported values are: debug, info, warn, and error. (default "info")
  -o, --output string      Output format. json or yaml.
  -p, --packages strings   names of packages.

getting kube config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

After:
```
idpbuilder get secrets
Error: getting kube config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
getting kube config: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
```

fixes: #439