### PR TITLE
Updates goreleaser.yaml to mark nightly builds as pre-release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,10 @@ project_name: idpbuilder
 before:
   hooks:
     - go mod tidy
+release:
+  # Mark nightly build as prerelease based on tag
+  prerelease: '{{ contains .Tag "-nightly" }}'
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -29,7 +33,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Fixes #459 