### PR TITLE
add labels to applications

### DIFF
--- a/api/v1alpha1/localbuild_types.go
+++ b/api/v1alpha1/localbuild_types.go
@@ -14,9 +14,12 @@ const (
 	CliStartTimeAnnotation = "cnoe.io/cli-start-time"
 	FieldManager           = "idpbuilder"
 	// If GetSecretLabelKey is set to GetSecretLabelValue on a kubernetes secret, secret key and values can be used by the get command.
-	CLISecretLabelKey   = "cnoe.io/cli-secret"
-	CLISecretLabelValue = "true"
-	PackageNameLabelKey = "cnoe.io/package-name"
+	CLISecretLabelKey      = "cnoe.io/cli-secret"
+	CLISecretLabelValue    = "true"
+	PackageNameLabelKey    = "cnoe.io/package-name"
+	PackageTypeLabelKey    = "cnoe.io/package-type"
+	PackageTypeLabelCore   = "core"
+	PackageTypeLabelCustom = "custom"
 
 	ArgoCDPackageName       = "argocd"
 	GiteaPackageName        = "gitea"

--- a/pkg/controllers/custompackage/controller.go
+++ b/pkg/controllers/custompackage/controller.go
@@ -93,6 +93,7 @@ func (r *Reconciler) reconcileCustomPackage(ctx context.Context, resource *v1alp
 		if !ok {
 			return ctrl.Result{}, fmt.Errorf("object is not an ArgoCD application %s", resource.Spec.ArgoCD.ApplicationFile)
 		}
+		util.SetPackageLabels(app)
 
 		res, err := r.reconcileArgoCDApp(ctx, resource, app)
 		if err != nil {
@@ -112,7 +113,7 @@ func (r *Reconciler) reconcileCustomPackage(ctx context.Context, resource *v1alp
 			}
 			return ctrl.Result{}, fmt.Errorf("getting argocd application object: %w", err)
 		}
-
+		util.SetPackageLabels(&foundAppObj)
 		foundAppObj.Spec = app.Spec
 		foundAppObj.ObjectMeta.Annotations = app.GetAnnotations()
 		foundAppObj.ObjectMeta.Labels = app.GetLabels()
@@ -128,10 +129,14 @@ func (r *Reconciler) reconcileCustomPackage(ctx context.Context, resource *v1alp
 		if !ok {
 			return ctrl.Result{}, fmt.Errorf("object is not an ArgoCD application set %s", resource.Spec.ArgoCD.ApplicationFile)
 		}
+
+		util.SetPackageLabels(appSet)
+
 		res, err := r.reconcileArgoCDAppSet(ctx, resource, appSet)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+
 		foundAppSetObj := argov1alpha1.ApplicationSet{}
 		err = r.Client.Get(ctx, client.ObjectKeyFromObject(appSet), &foundAppSetObj)
 		if err != nil {
@@ -145,6 +150,7 @@ func (r *Reconciler) reconcileCustomPackage(ctx context.Context, resource *v1alp
 			return ctrl.Result{}, fmt.Errorf("getting argocd application set object: %w", err)
 		}
 
+		util.SetPackageLabels(&foundAppSetObj)
 		foundAppSetObj.Spec = appSet.Spec
 		foundAppSetObj.ObjectMeta.Annotations = appSet.GetAnnotations()
 		foundAppSetObj.ObjectMeta.Labels = appSet.GetLabels()

--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -19,8 +19,10 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -234,6 +236,8 @@ func (r *LocalbuildReconciler) reconcileEmbeddedApp(ctx context.Context, appName
 		},
 	}
 
+	util.SetPackageLabels(app)
+
 	if err := controllerutil.SetControllerReference(resource, app, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -282,6 +286,30 @@ func (r *LocalbuildReconciler) shouldShutDown(ctx context.Context, resource *v1a
 		return false, err
 	}
 
+	// check if core packages are ready
+	selector := labels.NewSelector()
+	req, err := labels.NewRequirement(v1alpha1.PackageTypeLabelKey, selection.Equals, []string{v1alpha1.PackageTypeLabelCore})
+	if err != nil {
+		return false, fmt.Errorf("building labels with key %s and value %s : %w", v1alpha1.PackageTypeLabelKey, v1alpha1.PackageTypeLabelCore, err)
+	}
+
+	opts := client.ListOptions{
+		LabelSelector: selector.Add(*req),
+		Namespace:     "",
+	}
+	apps := argov1alpha1.ApplicationList{}
+	err = r.Client.List(ctx, &apps, &opts)
+	if err != nil {
+		return false, fmt.Errorf("listing core packages: %w", err)
+	}
+
+	for _, app := range apps.Items {
+		if app.Status.Health.Status != "Healthy" {
+			return false, nil
+		}
+	}
+
+	// check if repositories are ready
 	repos := &v1alpha1.GitRepositoryList{}
 	err = r.Client.List(ctx, repos, client.InNamespace(resource.Namespace))
 	if err != nil {
@@ -313,6 +341,7 @@ func (r *LocalbuildReconciler) shouldShutDown(ctx context.Context, resource *v1a
 		}
 	}
 
+	// check if custom packages are ready
 	pkgs := &v1alpha1.CustomPackageList{}
 	err = r.Client.List(ctx, pkgs, client.InNamespace(resource.Namespace))
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -167,3 +167,19 @@ func DetectKindNodeProvider() (cluster.ProviderOption, error) {
 		return cluster.DetectNodeProvider()
 	}
 }
+
+func SetPackageLabels(obj client.Object) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+		obj.SetLabels(labels)
+	}
+	labels[v1alpha1.PackageNameLabelKey] = obj.GetName()
+
+	switch n := obj.GetName(); n {
+	case v1alpha1.ArgoCDPackageName, v1alpha1.GiteaPackageName, v1alpha1.IngressNginxPackageName:
+		labels[v1alpha1.PackageTypeLabelKey] = v1alpha1.PackageTypeLabelCore
+	default:
+		labels[v1alpha1.PackageTypeLabelKey] = v1alpha1.PackageTypeLabelCustom
+	}
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,6 +3,12 @@ package util
 import (
 	"strconv"
 	"testing"
+
+	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var specialCharMap = make(map[string]struct{})
@@ -40,5 +46,91 @@ func TestGeneratePassword(t *testing.T) {
 		if counts[2] < numDigits {
 			t.Fatalf("min number of digits not generated")
 		}
+	}
+}
+
+type MockObject struct {
+	v1.ObjectMeta
+}
+
+func (m *MockObject) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+
+func (m *MockObject) DeepCopyObject() runtime.Object {
+	return nil
+}
+
+func TestSetPackageLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		objectName     string
+		initialLabels  map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name:          "No initial labels",
+			objectName:    "test-package",
+			initialLabels: nil,
+			expectedLabels: map[string]string{
+				v1alpha1.PackageNameLabelKey: "test-package",
+				v1alpha1.PackageTypeLabelKey: v1alpha1.PackageTypeLabelCustom,
+			},
+		},
+		{
+			name:       "With initial labels",
+			objectName: "test-package-one",
+			initialLabels: map[string]string{
+				"existing":                   "label",
+				v1alpha1.PackageNameLabelKey: "incorrect",
+			},
+			expectedLabels: map[string]string{
+				"existing":                   "label",
+				v1alpha1.PackageNameLabelKey: "test-package-one",
+				v1alpha1.PackageTypeLabelKey: v1alpha1.PackageTypeLabelCustom,
+			},
+		},
+		{
+			name:          "ArgoCD package",
+			objectName:    v1alpha1.ArgoCDPackageName,
+			initialLabels: nil,
+			expectedLabels: map[string]string{
+				v1alpha1.PackageNameLabelKey: v1alpha1.ArgoCDPackageName,
+				v1alpha1.PackageTypeLabelKey: v1alpha1.PackageTypeLabelCore,
+			},
+		},
+		{
+			name:          "Gitea package",
+			objectName:    v1alpha1.GiteaPackageName,
+			initialLabels: nil,
+			expectedLabels: map[string]string{
+				v1alpha1.PackageNameLabelKey: v1alpha1.GiteaPackageName,
+				v1alpha1.PackageTypeLabelKey: v1alpha1.PackageTypeLabelCore,
+			},
+		},
+		{
+			name:          "IngressNginx package",
+			objectName:    v1alpha1.IngressNginxPackageName,
+			initialLabels: nil,
+			expectedLabels: map[string]string{
+				v1alpha1.PackageNameLabelKey: v1alpha1.IngressNginxPackageName,
+				v1alpha1.PackageTypeLabelKey: v1alpha1.PackageTypeLabelCore,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &MockObject{
+				ObjectMeta: v1.ObjectMeta{
+					Name:   tc.objectName,
+					Labels: tc.initialLabels,
+				},
+			}
+
+			SetPackageLabels(obj)
+
+			assert.Equal(t, tc.expectedLabels, obj.GetLabels())
+		})
 	}
 }


### PR DESCRIPTION
This adds `cnoe.io/package-name` and `cnoe.io/package-type` labels to applications. Then use the label to wait for core packages to be healthy.