### PR TITLE
allow /e2e in PRs to run e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,8 @@ on:
       - '**.go'
       - 'go.sum'
       - 'go.mod'
+  repository_dispatch:
+    types: [e2e-command]
 jobs:
   e2e:
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,11 +10,15 @@ on:
       - 'go.mod'
   repository_dispatch:
     types: [e2e-command]
+
 jobs:
   e2e:
     runs-on: ubuntu-22.04
+    if: ${{ github.event.ref != '' }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
@@ -22,3 +26,21 @@ jobs:
       - name: Run tests
         run: |
           make e2e
+  # invoked by slash command workflow
+  e2e-slash-command:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event.action == 'e2e-command' }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: '1.22'
+      - name: Run tests
+        run: |
+          make e2e
+

--- a/.github/workflows/slash-commands.yaml
+++ b/.github/workflows/slash-commands.yaml
@@ -1,0 +1,24 @@
+name: slash-commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash_command_dispatch:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.CNOE_GH_WORKFLOW_TOKEN_APP_ID }}
+          private-key: ${{ secrets.CNOE_GH_WORKFLOW_TOKEN_PRIVATE_KEY }}
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commands: |
+            e2e
+          permission: write
+          issue-type: pull-request


### PR DESCRIPTION
This allows for people with `write` permissions to this repository to run the e2e workflow by commenting `/e2e` in PRs.


Tested here:  https://github.com/nabuskey/idpbuilder/pull/1

fixes: https://github.com/cnoe-io/idpbuilder/issues/254