### PR TITLE
Fix wrong import and replace entity with types from printer

### DIFF
--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -18,8 +18,8 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	argov1alpha1 "github.com/cnoe-io/argocd-api/api/argo/application/v1alpha1"
-	"github.com/cnoe-io/idpbuilder/pkg/entity"
 	"github.com/cnoe-io/idpbuilder/pkg/k8s"
+	"github.com/cnoe-io/idpbuilder/pkg/printer/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
@@ -268,7 +268,7 @@ func GetBasicAuth(ctx context.Context, name string) (BasicAuth, error) {
 			}
 
 			out := BasicAuth{}
-			secs := make([]entity.Secret, 2)
+			secs := make([]types.Secret, 2)
 			if err = json.Unmarshal(b, &secs); err != nil {
 				lastErr = err
 				time.Sleep(httpRetryDelay)
@@ -383,7 +383,7 @@ func TestGiteaRegistry(ctx context.Context, t *testing.T, cmd, giteaHost, giteaP
 	b, err := RunCommand(ctx, fmt.Sprintf("%s get secrets -o json -p gitea", IdpbuilderBinaryLocation), 10*time.Second)
 	assert.NoError(t, err)
 
-	secs := make([]entity.Secret, 1)
+	secs := make([]types.Secret, 1)
 	err = json.Unmarshal(b, &secs)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
- Fix wrong import and replace entity with types from printer to fix e2e tests failing