### PR TITLE
Expose the gitea ssh port on 32222

### DIFF
--- a/hack/gitea/values.yaml
+++ b/hack/gitea/values.yaml
@@ -27,6 +27,8 @@ gitea:
     server:
       DOMAIN: '{{- if .UsePathRouting -}} {{ .Host }} {{- else -}} gitea.{{- .Host }} {{- end }}'
       ROOT_URL: '{{- if .UsePathRouting }} {{- .Protocol }}://{{ .Host }}:{{ .Port }}/gitea {{- else }} {{- .Protocol }}://gitea.{{ .Host }}:{{ .Port }} {{- end }}'
+      SSH_PORT: 32222
+      SSH_LISTEN_PORT: 2222
     webhook:
       ALLOWED_HOST_LIST: private
       SKIP_TLS_VERIFY: true
@@ -34,6 +36,7 @@ gitea:
 service:
   ssh:
     type: NodePort
+    port: 32222
     nodePort: 32222
     externalTrafficPolicy: Local
 

--- a/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
+++ b/pkg/controllers/localbuild/resources/gitea/k8s/install.yaml
@@ -36,7 +36,7 @@ stringData:
     ROOT_URL={{- if .UsePathRouting }} {{- .Protocol }}://{{ .Host }}:{{ .Port }}/gitea {{- else }} {{- .Protocol }}://gitea.{{ .Host }}:{{ .Port }} {{- end }}
     SSH_DOMAIN={{- if .UsePathRouting -}} {{ .Host }} {{- else -}} gitea.{{- .Host }} {{- end }}
     SSH_LISTEN_PORT=2222
-    SSH_PORT=22
+    SSH_PORT=32222
     START_SSH_SERVER=true
   session: |-
     PROVIDER=memory
@@ -381,7 +381,7 @@ spec:
   externalTrafficPolicy: Local
   ports:
   - name: ssh
-    port: 22
+    port: 32222
     targetPort: 2222
     protocol: TCP
     nodePort: 32222
@@ -417,7 +417,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94b0102e29e8bd17652180743c848722b184530813c36ad9fe0705edc22cc716
+        checksum/config: 9472556301411a93ff19830db2ba46ea781c96364243b2f06ab8e33fb785c25d
       labels:
         helm.sh/chart: gitea-10.1.4
         app: gitea
@@ -539,7 +539,7 @@ spec:
             - name: SSH_LISTEN_PORT
               value: "2222"
             - name: SSH_PORT
-              value: "22"
+              value: "32222"
             - name: GITEA_APP_INI
               value: /data/gitea/conf/app.ini
             - name: GITEA_CUSTOM

--- a/pkg/kind/cluster_test.go
+++ b/pkg/kind/cluster_test.go
@@ -42,6 +42,9 @@ nodes:
   - containerPort: 443
     hostPort: 8443
     protocol: TCP
+  - containerPort: 32222
+    hostPort: 32222
+    protocol: TCP
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gitea.cnoe.localtest.me:8443"]
@@ -64,6 +67,9 @@ nodes:
   extraPortMappings:
   - containerPort: 443
     hostPort: 8443
+    protocol: TCP
+  - containerPort: 32222
+    hostPort: 32222
     protocol: TCP
 
 containerdConfigPatches:
@@ -116,6 +122,9 @@ nodes:
   extraPortMappings:
   - containerPort: 443
     hostPort: 8443
+    protocol: TCP
+  - containerPort: 32222
+    hostPort: 32222
     protocol: TCP
   - containerPort: 32222
     hostPort: 22

--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -9,6 +9,9 @@ nodes:
   - containerPort: {{ if (eq .Protocol "http")  -}} 80 {{- else -}} 443 {{- end }}
     hostPort: {{ .Port }}
     protocol: TCP
+  - containerPort: 32222
+    hostPort: 32222
+    protocol: TCP
   {{ range .ExtraPortsMapping -}}
   - containerPort: {{ .ContainerPort }}
     hostPort: {{ .HostPort }}


### PR DESCRIPTION
Sets up gitea ssh to be exposed at 32222 on the host network, container, and service layers.

It's unclear to me if we always want to expose this port. If we decide the host port we can ensure the gitea `SSH_PORT` setting matches which makes the ssh clone URL in gitea work.

fixes https://github.com/cnoe-io/idpbuilder/issues/227