### PR TITLE
fix: failing release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
         with:
           app-id: ${{ vars.CNOE_HOMEBREW_APP_ID }}
           private-key: ${{ secrets.CNOE_HOMEBREW_PRIVATE_KEY }}
+          repositories: |
+            homebrew-tap
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         id: run-goreleaser


### PR DESCRIPTION
For homebrew-tap token create-token GH action requires repository to be specified otherwise it will create token only for the current repository. 
Ref: https://github.com/actions/create-github-app-token?tab=readme-ov-file#repositories

fixes: #479 