### PR TITLE
fix: mark nightly release as prerelease

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
     - go mod tidy
 release:
   # Mark nightly build as prerelease based on tag
-  prerelease: '{{ contains .Tag "-nightly" }}'
+  prerelease: auto
 
 builds:
   - env:


### PR DESCRIPTION
Changes goreleaser for marking nightly releases as prerelease.
Ref: https://goreleaser.com/customization/release/#github