### PR TITLE
Add registry-config option

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -33,6 +33,7 @@ type Build struct {
 	kubeConfigPath       string
 	kubeVersion          string
 	extraPortsMapping    string
+	registryConfig       []string
 	customPackageDirs    []string
 	customPackageUrls    []string
 	packageCustomization map[string]v1alpha1.PackageCustomization
@@ -48,6 +49,7 @@ type NewBuildOptions struct {
 	KubeConfigPath       string
 	KubeVersion          string
 	ExtraPortsMapping    string
+	RegistryConfig       []string
 	CustomPackageDirs    []string
 	CustomPackageUrls    []string
 	PackageCustomization map[string]v1alpha1.PackageCustomization
@@ -63,6 +65,7 @@ func NewBuild(opts NewBuildOptions) *Build {
 		kubeConfigPath:       opts.KubeConfigPath,
 		kubeVersion:          opts.KubeVersion,
 		extraPortsMapping:    opts.ExtraPortsMapping,
+		registryConfig:       opts.RegistryConfig,
 		customPackageDirs:    opts.CustomPackageDirs,
 		customPackageUrls:    opts.CustomPackageUrls,
 		packageCustomization: opts.PackageCustomization,
@@ -75,7 +78,7 @@ func NewBuild(opts NewBuildOptions) *Build {
 
 func (b *Build) ReconcileKindCluster(ctx context.Context, recreateCluster bool) error {
 	// Initialize Kind Cluster
-	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.kindConfigPath, b.extraPortsMapping, b.cfg, setupLog)
+	cluster, err := kind.NewCluster(b.name, b.kubeVersion, b.kubeConfigPath, b.kindConfigPath, b.extraPortsMapping, b.registryConfig, b.cfg, setupLog)
 	if err != nil {
 		setupLog.Error(err, "Error Creating kind cluster")
 		return err

--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -12,11 +12,16 @@ nodes:
   - containerPort: 32222
     hostPort: 32222
     protocol: TCP
-  {{ range .ExtraPortsMapping -}}
+  {{- range .ExtraPortsMapping }}
   - containerPort: {{ .ContainerPort }}
     hostPort: {{ .HostPort }}
     protocol: TCP
-  {{ end }}
+  {{- end }}
+{{- if .RegistryConfig }}
+  extraMounts:
+  - containerPath: /var/lib/kubelet/config.json
+    hostPath: {{ .RegistryConfig }}
+{{- end }}
 containerdConfigPatches:
 - |-
   {{ if .UsePathRouting -}}


### PR DESCRIPTION
The new registry-config option when used alone looks up the default
podman and docker registry config files and mounts them in the kind
container if they exist. Optionally a user can pass a specific file to
the flag to specify a custom path to mount as the registry config.