### PR TITLE
Restrict ingress port forwarding when using --dev-password

### DIFF
--- a/pkg/kind/resources/kind.yaml.tmpl
+++ b/pkg/kind/resources/kind.yaml.tmpl
@@ -8,6 +8,9 @@ nodes:
   extraPortMappings:
   - containerPort: {{ if (eq .Protocol "http")  -}} 80 {{- else -}} 443 {{- end }}
     hostPort: {{ .Port }}
+    {{- if .StaticPassword }}
+    listenAddress: "127.0.0.1"
+    {{- end }}
     protocol: TCP
   - containerPort: 32222
     hostPort: 32222


### PR DESCRIPTION
forwarding our ingress to the host node and listening on 0.0.0.0 can potentially be dangerous, particularly if a user is using the --dev-password flag to use an insecure static password. In that case someone could potentially access their gitea/argocd install and run arbitrary pods in the cluster.