### PR TITLE
fix bugs around kube config path flags

### DIFF
--- a/pkg/cmd/get/clusters.go
+++ b/pkg/cmd/get/clusters.go
@@ -63,18 +63,17 @@ func populateClusterList() ([]idpTypes.Cluster, error) {
 		return nil, err
 	}
 
-	kubeConfig, err := helpers.GetKubeConfig()
+	kubeConfig, err := util.GetKubeConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: Check if we need it or not like also if the new code handle the kubeconfig path passed as parameter
-	_, err = helpers.GetKubeClient(kubeConfig)
+	_, err = util.GetKubeClient(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	config, err := helpers.LoadKubeConfig()
+	config, err := util.LoadKubeConfig()
 	if err != nil {
 		//logger.Error(err, "failed to load the kube config.")
 		return nil, err

--- a/pkg/cmd/get/packages.go
+++ b/pkg/cmd/get/packages.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
-	"github.com/cnoe-io/idpbuilder/pkg/build"
-	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/printer"
 	"github.com/cnoe-io/idpbuilder/pkg/printer/types"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
 	"io"
-	"k8s.io/client-go/util/homedir"
 	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 )
@@ -29,23 +25,13 @@ var PackagesCmd = &cobra.Command{
 func getPackagesE(cmd *cobra.Command, args []string) error {
 	ctx, ctxCancel := context.WithCancel(cmd.Context())
 	defer ctxCancel()
-	kubeConfigPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
 
-	opts := build.NewBuildOptions{
-		KubeConfigPath: kubeConfigPath,
-		Scheme:         k8s.GetScheme(),
-		CancelFunc:     ctxCancel,
-		TemplateData:   v1alpha1.BuildCustomizationSpec{},
-	}
-
-	b := build.NewBuild(opts)
-
-	kubeConfig, err := b.GetKubeConfig()
+	kubeConfig, err := util.GetKubeConfig()
 	if err != nil {
 		return fmt.Errorf("getting kube config: %w", err)
 	}
 
-	kubeClient, err := b.GetKubeClient(kubeConfig)
+	kubeClient, err := util.GetKubeClient(kubeConfig)
 	if err != nil {
 		return fmt.Errorf("getting kube client: %w", err)
 	}

--- a/pkg/cmd/get/root.go
+++ b/pkg/cmd/get/root.go
@@ -2,7 +2,7 @@ package get
 
 import (
 	"fmt"
-	"github.com/cnoe-io/idpbuilder/pkg/cmd/helpers"
+	"github.com/cnoe-io/idpbuilder/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -24,7 +24,7 @@ func init() {
 	GetCmd.AddCommand(PackagesCmd)
 	GetCmd.PersistentFlags().StringSliceVarP(&packages, "packages", "p", []string{}, "names of packages.")
 	GetCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table (default if not specified), json or yaml.")
-	GetCmd.PersistentFlags().StringVarP(&helpers.KubeConfigPath, "kubeconfig", "", "", "kube config file Path.")
+	GetCmd.PersistentFlags().StringVarP(&util.KubeConfigPath, "kubeconfig", "", "", "kube config file Path.")
 }
 
 func exportE(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/get/secrets.go
+++ b/pkg/cmd/get/secrets.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
-	"github.com/cnoe-io/idpbuilder/pkg/build"
-	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"github.com/cnoe-io/idpbuilder/pkg/printer"
 	"github.com/cnoe-io/idpbuilder/pkg/printer/types"
 	"github.com/cnoe-io/idpbuilder/pkg/util"
@@ -15,9 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/util/homedir"
 	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -46,22 +42,13 @@ var (
 func getSecretsE(cmd *cobra.Command, args []string) error {
 	ctx, ctxCancel := context.WithCancel(cmd.Context())
 	defer ctxCancel()
-	kubeConfigPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
 
-	opts := build.NewBuildOptions{
-		KubeConfigPath: kubeConfigPath,
-		Scheme:         k8s.GetScheme(),
-		CancelFunc:     ctxCancel,
-	}
-
-	b := build.NewBuild(opts)
-
-	kubeConfig, err := b.GetKubeConfig()
+	kubeConfig, err := util.GetKubeConfig()
 	if err != nil {
 		return fmt.Errorf("getting kube config: %w", err)
 	}
 
-	kubeClient, err := b.GetKubeClient(kubeConfig)
+	kubeClient, err := util.GetKubeClient(kubeConfig)
 	if err != nil {
 		return fmt.Errorf("getting kube client: %w", err)
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -8,19 +8,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func GetKubeClient() (client.Client, error) {
-	conf, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
-	if err != nil {
-		return nil, err
-	}
-	return client.New(conf, client.Options{Scheme: GetScheme()})
-}
 
 func EnsureObject(ctx context.Context, kubeClient client.Client, obj client.Object, namespace string) error {
 	curObj := &unstructured.Unstructured{}

--- a/pkg/util/argocd.go
+++ b/pkg/util/argocd.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"github.com/cnoe-io/idpbuilder/pkg/util/idp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,7 +15,7 @@ const (
 )
 
 func ArgocdBaseUrl(ctx context.Context) (string, error) {
-	idpConfig, err := idp.GetConfig(ctx)
+	idpConfig, err := GetConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error fetching idp config: %s", err)
 	}

--- a/pkg/util/gitea.go
+++ b/pkg/util/gitea.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
-	"github.com/cnoe-io/idpbuilder/pkg/util/idp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -114,7 +113,7 @@ func GetGiteaToken(ctx context.Context, baseUrl, username, password string) (str
 }
 
 func GiteaBaseUrl(ctx context.Context) (string, error) {
-	idpConfig, err := idp.GetConfig(ctx)
+	idpConfig, err := GetConfig(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error fetching idp config: %s", err)
 	}

--- a/pkg/util/idp.go
+++ b/pkg/util/idp.go
@@ -1,18 +1,23 @@
-package idp
+package util
 
 import (
 	"context"
+	"fmt"
 	"github.com/cnoe-io/idpbuilder/api/v1alpha1"
-	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func GetConfig(ctx context.Context) (v1alpha1.BuildCustomizationSpec, error) {
 	b := v1alpha1.BuildCustomizationSpec{}
 
-	kubeClient, err := k8s.GetKubeClient()
+	kubeConfig, err := GetKubeConfig()
 	if err != nil {
-		return b, err
+		return b, fmt.Errorf("getting kube config: %w", err)
+	}
+
+	kubeClient, err := GetKubeClient(kubeConfig)
+	if err != nil {
+		return b, fmt.Errorf("getting kube client: %w", err)
 	}
 
 	list, err := getLocalBuild(ctx, kubeClient)

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -1,8 +1,8 @@
-package helpers
+package util
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
+	"github.com/cnoe-io/idpbuilder/pkg/k8s"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -13,7 +13,6 @@ import (
 
 var (
 	KubeConfigPath string
-	scheme         *runtime.Scheme
 )
 
 func GetKubeConfigPath() string {
@@ -42,7 +41,7 @@ func GetKubeConfig() (*rest.Config, error) {
 }
 
 func GetKubeClient(kubeConfig *rest.Config) (client.Client, error) {
-	kubeClient, err := client.New(kubeConfig, client.Options{Scheme: scheme})
+	kubeClient, err := client.New(kubeConfig, client.Options{Scheme: k8s.GetScheme()})
 	if err != nil {
 		return nil, fmt.Errorf("Error creating kubernetes client: %w", err)
 	}


### PR DESCRIPTION
This centralizes the GetKubeClient and GetKubeConfig functions so that we're always using the right kube config path