### PR TITLE
don't set the admin password repeatedly when using --dev-password

### DIFF
--- a/pkg/controllers/localbuild/controller.go
+++ b/pkg/controllers/localbuild/controller.go
@@ -115,7 +115,7 @@ func (r *LocalbuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		// Secret containing the initial argocd password exists
 		// Lets try to update the password
-		if argocdInitialAdminPassword != "" {
+		if argocdInitialAdminPassword != "" && argocdInitialAdminPassword != util.StaticPassword {
 			err = r.updateArgocdPassword(ctx, argocdInitialAdminPassword)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -133,7 +133,7 @@ func (r *LocalbuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.V(1).Info("Gitea admin secret found ...")
 		// Secret containing the gitea password exists
 		// Lets try to update the password
-		if giteaAdminPassword != "" {
+		if giteaAdminPassword != "" && giteaAdminPassword != util.StaticPassword {
 			err = r.updateGiteaPassword(ctx, giteaAdminPassword)
 			if err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
Every time we change the admin password in argocd it clears the active user sessions. This makes iteration with developing stacks a bit tedious as you end up running `idpbuilder --dev-password -p stackname` a lot and you have to log back into argo every time. This is a minor inconvenience but I don't see any reason we can't fix it.