### PR TITLE
Disable formula upload of idpbuilder.rb for nightly builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,7 @@ brews:
 # For non version installations
   - name: "idpbuilder" 
     homepage: "https://cnoe.io"
+    skip_upload: "{{ contains .Tag \"nightly\" }}" # Don't upload this formula if the build is nightly
     repository:
       owner: cnoe-io
       name: homebrew-tap
@@ -44,7 +45,7 @@ brews:
     test: |
       system "#{bin}/idpbuilder version"
 # For versioned and nightly installations
-  - name: "{{ if contains .Tag \"nightly\" }}idpbuilder@nightly{{ else }}idpbuilder@{{ .Major }}.{{ .Minor }}.{{ .Patch }}{{ end }}"
+  - name: "{{ if contains .Tag \"nightly\" }}idpbuilder-nightly{{ else }}idpbuilder@{{ .Major }}.{{ .Minor }}.{{ .Patch }}{{ end }}"
     homepage: "https://cnoe.io"
     repository:
       owner: cnoe-io

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This can be useful in several ways:
 + Nightly Version
 
    ```bash
-   brew install cnoe-io/tap/idpbuilder@nightly
+   brew install cnoe-io/tap/idpbuilder-nightly
    ```
 
 ### From Releases


### PR DESCRIPTION
Configure goreleaser not to publish formula `idpbuilder.rb` if the build is nigtly. For nightly. build, it should only update formula in `idpbuilder-nightly.rb`. This way following instruction for installing idpbuilder would work as intended.
 
+ Stable Version

   ```bash
   brew install cnoe-io/tap/idpbuilder
   ```
+ Specific Stable Version

   ```bash
   brew install cnoe-io/tap/idpbuilder@<version>
   ```
+ Nightly Version

   ```bash
   brew install cnoe-io/tap/idpbuilder-nightly
   ```