### PR TITLE
fix: installation script semver matching

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -3,7 +3,7 @@
 set -e -o pipefail
 # get the latest stable release by look for tag name pattern like 'v*.*.*'.  For example, v1.1.1
 # GitHub API returns releases in chronological order so we take the first matching tag name.
-version=$(curl -s https://api.github.com/repos/cnoe-io/idpbuilder/releases | grep tag_name | grep -o -e '"v[0-9].[0-9].[0-9]"' | head -n1 | sed 's/"//g')
+version=$(curl -s https://api.github.com/repos/cnoe-io/idpbuilder/releases | grep tag_name | grep -o -E '"v[0-9]+\.[0-9]+\.[0-9]+"' | head -n1 | sed 's/"//g')
 
 echo "Downloading idpbuilder version ${version}"
 curl -L --progress-bar -o ./idpbuilder.tar.gz "https://github.com/cnoe-io/idpbuilder/releases/download/${version}/idpbuilder-$(uname | awk '{print tolower($0)}')-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/').tar.gz"


### PR DESCRIPTION
## Issue
The current installation script uses an improper regex for semver matching, which only matches individual version (major, minor & patch) with single digit only. Consequently, the installation script doesn't install the latest stable version.

## Fix
Update regex to enable proper matching

`"v[0-9].[0-9].[0-9]"` -> `"v[0-9]+\.[0-9]+\.[0-9]+"`