### PR TITLE
fix: skip malformed extra port mapping entries

### DIFF
--- a/pkg/kind/config.go
+++ b/pkg/kind/config.go
@@ -65,12 +65,12 @@ func parsePortMappings(extraPortsMapping string) []PortMapping {
 		// Split pairs of ports "11=1111","22=2222",etc
 		pairs := strings.Split(extraPortsMapping, ",")
 		// Create a slice to store PortMapping pairs.
-		portMappingPairs = make([]PortMapping, len(pairs))
+		portMappingPairs = make([]PortMapping, 0, len(pairs))
 		// Parse each pair into PortPair objects.
-		for i, pair := range pairs {
+		for _, pair := range pairs {
 			parts := strings.Split(pair, ":")
 			if len(parts) == 2 {
-				portMappingPairs[i] = PortMapping{parts[0], parts[1]}
+				portMappingPairs = append(portMappingPairs, PortMapping{parts[0], parts[1]})
 			}
 		}
 	}

--- a/pkg/kind/config_test.go
+++ b/pkg/kind/config_test.go
@@ -304,3 +304,22 @@ func TestRenderRegistryCertsDirWithMirrors(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePortMappingsSkipsMalformedPairs(t *testing.T) {
+	// A malformed pair (no colon) must be skipped, not left as a zero-value
+	// PortMapping in the returned slice, otherwise an empty mapping leaks into
+	// the generated kind config.
+	out := parsePortMappings("11:1111,badpair,33:3333")
+	expected := []PortMapping{
+		{HostPort: "11", ContainerPort: "1111"},
+		{HostPort: "33", ContainerPort: "3333"},
+	}
+	if !reflect.DeepEqual(expected, out) {
+		t.Errorf("expected: %v, got: %v", expected, out)
+	}
+	for _, pm := range out {
+		if pm.HostPort == "" || pm.ContainerPort == "" {
+			t.Errorf("empty port mapping leaked into result: %+v", out)
+		}
+	}
+}


### PR DESCRIPTION
parsePortMappings preallocated the result slice with len(pairs) and wrote by index, so a malformed entry left an empty PortMapping in the slice that flowed into the generated kind config.

Switched to append so malformed pairs are skipped instead of leaking a zero value mapping.